### PR TITLE
Trim the source before parsing it

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ pub enum MinusOneErrorKind {
     Parsing,
     InvalidChildIndex,
     InvalidParent,
+    InvalidProgramIndex,
     Unknown,
 }
 
@@ -63,6 +64,17 @@ impl Error {
         Error::MinusOneError(MinusOneError::new(
             MinusOneErrorKind::InvalidChildIndex,
             "A child was expected at this index",
+        ))
+    }
+
+    pub fn invalid_program_index(index: usize) -> Self {
+        Error::MinusOneError(MinusOneError::new(
+            MinusOneErrorKind::InvalidProgramIndex,
+            format!(
+                "The program is excepted to start at index 0. Found index {}",
+                index
+            )
+            .as_str(),
         ))
     }
 

--- a/src/ps/linter.rs
+++ b/src/ps/linter.rs
@@ -388,6 +388,10 @@ impl<'a> Rule<'a> for RemoveComment {
         // depending on what am i
         match node.kind() {
             "program" => {
+                if node.start_abs() != 0 {
+                    panic!("Program does not start at index 0 after trimming the source.");
+                }
+
                 self.source = node.text()?.to_string();
             }
             "comment" => {
@@ -402,7 +406,16 @@ impl<'a> Rule<'a> for RemoveComment {
     /// the down to top
     fn leave(&mut self, node: &Node<'a, Self::Language>) -> MinusOneResult<()> {
         match node.kind() {
-            "program" => self.output += &self.source[self.last_index..],
+            "program" => {
+                // println!(
+                //     "DEBUGING:\noutput:\n{}\n\nsource:\n{}\n\nlastindex:\n{}\n\nnode:\n{}\n",
+                //     self.output,
+                //     self.source,
+                //     self.last_index,
+                //     node.text().unwrap()
+                // );
+                self.output += &self.source[self.last_index..]
+            }
             _ => (),
         }
 

--- a/src/ps/linter.rs
+++ b/src/ps/linter.rs
@@ -1,4 +1,4 @@
-use error::MinusOneResult;
+use error::{Error, MinusOneResult};
 use ps::Powershell;
 use ps::Powershell::Raw;
 use ps::Value::{Bool, Num, Str};
@@ -389,7 +389,7 @@ impl<'a> Rule<'a> for RemoveComment {
         match node.kind() {
             "program" => {
                 if node.start_abs() != 0 {
-                    panic!("Program does not start at index 0 after trimming the source.");
+                    return Err(Error::invalid_program_index(node.start_abs()));
                 }
 
                 self.source = node.text()?.to_string();

--- a/src/ps/linter.rs
+++ b/src/ps/linter.rs
@@ -406,16 +406,7 @@ impl<'a> Rule<'a> for RemoveComment {
     /// the down to top
     fn leave(&mut self, node: &Node<'a, Self::Language>) -> MinusOneResult<()> {
         match node.kind() {
-            "program" => {
-                // println!(
-                //     "DEBUGING:\noutput:\n{}\n\nsource:\n{}\n\nlastindex:\n{}\n\nnode:\n{}\n",
-                //     self.output,
-                //     self.source,
-                //     self.last_index,
-                //     node.text().unwrap()
-                // );
-                self.output += &self.source[self.last_index..]
-            }
+            "program" => self.output += &self.source[self.last_index..],
             _ => (),
         }
 

--- a/src/ps/mod.rs
+++ b/src/ps/mod.rs
@@ -19,9 +19,6 @@ use ps::var::{StaticVar, Var};
 use tree::{HashMapStorage, Tree};
 use tree_sitter_powershell::language as powershell_language;
 
-use std::fs::File;
-use std::io::prelude::*;
-
 pub mod access;
 pub mod array;
 pub mod bool;

--- a/src/ps/mod.rs
+++ b/src/ps/mod.rs
@@ -19,6 +19,9 @@ use ps::var::{StaticVar, Var};
 use tree::{HashMapStorage, Tree};
 use tree_sitter_powershell::language as powershell_language;
 
+use std::fs::File;
+use std::io::prelude::*;
+
 pub mod access;
 pub mod array;
 pub mod bool;
@@ -124,6 +127,9 @@ pub type RuleSet = (
 pub fn remove_powershell_extra(source: &str) -> MinusOneResult<String> {
     let mut parser = tree_sitter::Parser::new();
     parser.set_language(&powershell_language()).unwrap();
+
+    // Trim to assert program is at the beginning
+    let source = source.trim();
 
     // Powershell is case insensitive
     // And the grammar is specified in lowercase


### PR DESCRIPTION
Fix out of bounds bug when removing comments

To trigger the bug before the fix, create this file:
```powershell


# test
echo 1
# test
```
Encode it with \r\n, in Windows style.
On Linux, you can use `unix2dos`

And run minusone on it:
```bash
$ cargo run --features=minusone-cli -- --path /tmp/a 
warning: no edition set: defaulting to the 2015 edition while the latest is 2024
   Compiling tree-sitter v0.24.7
   Compiling tree-sitter-traversal2 v0.2.0
   Compiling tree-sitter-powershell v0.24.4 (https://github.com/airbus-cert/tree-sitter-powershell?tag=v0.24.4#b3fe6563)
   Compiling minusone v0.3.1 (/home/alex/ghq/github.com/airbus-CERT/minusone)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.56s
     Running `target/debug/minusone-cli --path /tmp/a`

thread 'main' panicked at src/ps/linter.rs:405:53:
byte index 35 is out of bounds of `# testestestes
echo 1
# test
`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```