### PR TITLE
Check if program is valid before removing comments

### DIFF
--- a/src/bin/minusone-cli.rs
+++ b/src/bin/minusone-cli.rs
@@ -4,7 +4,7 @@ extern crate tree_sitter_powershell;
 
 use clap::{App, Arg};
 use minusone::engine::DeobfuscateEngine;
-use std::fs;
+use std::{fs, process};
 
 const APPLICATION_NAME: &str = "minusone-cli";
 
@@ -38,18 +38,25 @@ fn main() {
     .unwrap();
 
     // Always remove extra rule (comments) to get an accurate version of the deobfuscated scripts
-    let remove_comment = DeobfuscateEngine::remove_extra(&source).unwrap();
-    let mut engine = DeobfuscateEngine::from_powershell(&remove_comment).unwrap();
-    engine.deobfuscate().unwrap();
+    match DeobfuscateEngine::remove_extra(&source) {
+        Ok(remove_comment) => {
+            let mut engine = DeobfuscateEngine::from_powershell(&remove_comment).unwrap();
+            engine.deobfuscate().unwrap();
 
-    if matches.is_present("debug") {
-        engine.debug();
-    } else {
-        println!("{}", engine.lint().unwrap());
-    }
+            if matches.is_present("debug") {
+                engine.debug();
+            } else {
+                println!("{}", engine.lint().unwrap());
+            }
 
-    if matches.is_present("time") {
-        let elapsed = now.elapsed();
-        println!("\n\nElapsed: {:.2?}", elapsed);
+            if matches.is_present("time") {
+                let elapsed = now.elapsed();
+                println!("\n\nElapsed: {:.2?}", elapsed);
+            }
+        }
+        Err(e) => {
+            eprintln!("[x] ERROR: Cannot clean the source\n--> {:?}", e);
+            process::exit(1);
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ pub enum MinusOneErrorKind {
     Parsing,
     InvalidChildIndex,
     InvalidParent,
+    InvalidProgram,
     InvalidProgramIndex,
     Unknown,
 }
@@ -64,6 +65,13 @@ impl Error {
         Error::MinusOneError(MinusOneError::new(
             MinusOneErrorKind::InvalidChildIndex,
             "A child was expected at this index",
+        ))
+    }
+
+    pub fn invalid_program() -> Self {
+        Error::MinusOneError(MinusOneError::new(
+            MinusOneErrorKind::InvalidProgram,
+            "A valid program root node is excepted.",
         ))
     }
 

--- a/src/ps/linter.rs
+++ b/src/ps/linter.rs
@@ -1,4 +1,4 @@
-use error::{Error, MinusOneResult};
+use error::MinusOneResult;
 use ps::Powershell;
 use ps::Powershell::Raw;
 use ps::Value::{Bool, Num, Str};
@@ -388,10 +388,6 @@ impl<'a> Rule<'a> for RemoveComment {
         // depending on what am i
         match node.kind() {
             "program" => {
-                if node.start_abs() != 0 {
-                    return Err(Error::invalid_program_index(node.start_abs()));
-                }
-
                 self.source = node.text()?.to_string();
             }
             "comment" => {


### PR DESCRIPTION
Fix another bug in comment cleaner
Move the check in 8f0bfe039a6dcc64cf426000a9d278a09bb7a37f to the engine itself
Fix the cli for better error output