### PR TITLE
Chores: Clippy fixes, cargo warnings, and import cleanup

### DIFF
--- a/src/bin/minusone-cli.rs
+++ b/src/bin/minusone-cli.rs
@@ -1,3 +1,6 @@
+extern crate clap;
+extern crate minusone;
+
 use clap::{App, Arg};
 use minusone::engine::DeobfuscateEngine;
 use std::{fs, process};

--- a/src/bin/minusone-cli.rs
+++ b/src/bin/minusone-cli.rs
@@ -1,7 +1,3 @@
-extern crate clap;
-extern crate minusone;
-extern crate tree_sitter_powershell;
-
 use clap::{App, Arg};
 use minusone::engine::DeobfuscateEngine;
 use std::{fs, process};

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -26,8 +26,6 @@ impl<T> DebugView<T> {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::{build_powershell_tree, Powershell};
 /// use minusone::debug::DebugView;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,7 +1,7 @@
-use error::MinusOneResult;
-use rule::Rule;
+use crate::error::MinusOneResult;
+use crate::rule::Rule;
+use crate::tree::Node;
 use std::fmt::Debug;
-use tree::Node;
 
 /// A debug view is used to print the tree nodes
 /// with associated inferred type

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -30,7 +30,7 @@ impl<'a> DeobfuscateEngine<'a> {
     pub fn deobfuscate(&mut self) -> MinusOneResult<()> {
         self.root.apply_mut_with_strategy(
             &mut ps::RuleSet::init(),
-            ps::strategy::PowershellStrategy::default(),
+            ps::strategy::PowershellStrategy,
         )?;
         Ok(())
     }
@@ -38,14 +38,14 @@ impl<'a> DeobfuscateEngine<'a> {
     pub fn lint(&mut self) -> MinusOneResult<String> {
         let mut ps_litter_view = ps::linter::Linter::new();
         self.root.apply(&mut ps_litter_view)?;
-        Ok(CleanEngine::from_powershell(&ps_litter_view.output)?.clean()?)
+        CleanEngine::from_powershell(&ps_litter_view.output)?.clean()
     }
 
     pub fn lint_format(&mut self, tab_chr: &str) -> MinusOneResult<String> {
         let mut ps_litter_view = ps::linter::Linter::new().set_tab(tab_chr);
         self.root.apply(&mut ps_litter_view)?;
 
-        Ok(CleanEngine::from_powershell(&ps_litter_view.output)?.clean()?)
+        CleanEngine::from_powershell(&ps_litter_view.output)?.clean()
     }
 }
 
@@ -65,6 +65,6 @@ impl<'a> CleanEngine<'a> {
         )?;
         let mut clean_view = RemoveUnusedVar::new(rule);
         self.root.apply(&mut clean_view)?;
-        Ok(clean_view.clear()?)
+        clean_view.clear()
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,10 +1,10 @@
-use debug::DebugView;
-use error::MinusOneResult;
-use init::Init;
-use ps;
-use ps::{build_powershell_tree_for_storage, remove_powershell_extra};
-use ps::linter::RemoveUnusedVar;
-use tree::{EmptyStorage, HashMapStorage, Storage, Tree};
+use crate::debug::DebugView;
+use crate::error::MinusOneResult;
+use crate::init::Init;
+use crate::ps;
+use crate::ps::{build_powershell_tree_for_storage, remove_powershell_extra};
+use crate::ps::linter::RemoveUnusedVar;
+use crate::tree::{EmptyStorage, HashMapStorage, Storage, Tree};
 
 pub struct Engine<'a, S: Storage> {
     root: Tree<'a, S>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,8 +75,7 @@ impl Error {
         Error::MinusOneError(MinusOneError::new(
             MinusOneErrorKind::InvalidProgramIndex,
             format!(
-                "The program is excepted to start at index 0. Found index {}",
-                index
+                "The program is excepted to start at index 0. Found index {index}"
             )
             .as_str(),
         ))

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,6 @@ impl MinusOneError {
     /// create a new MinusOne error
     /// # Example
     /// ```
-    /// extern crate minusone;
-    ///
     /// use minusone::error::{MinusOneError, MinusOneErrorKind};
     /// let error = MinusOneError::new(MinusOneErrorKind::Unknown, "Unknown");
     /// ```
@@ -38,8 +36,6 @@ impl MinusOneError {
     ///
     /// # Example
     /// ```
-    /// extern crate minusone;
-    ///
     /// use minusone::error::{MinusOneError, MinusOneErrorKind};
     /// let error = MinusOneError::new(MinusOneErrorKind::Unknown, "unknown");
     /// assert_eq!(error.kind(), MinusOneErrorKind::Unknown)

--- a/src/ps/access.rs
+++ b/src/ps/access.rs
@@ -1,9 +1,9 @@
-use error::MinusOneResult;
-use ps::Powershell::{Array, Raw};
-use ps::Value::Str;
-use ps::{Powershell, Value};
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell::{Array, Raw};
+use crate::ps::Value::Str;
+use crate::ps::{Powershell, Value};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// This function get char at index position
 /// even if the index is negative
@@ -281,11 +281,11 @@ impl<'a> RuleMut<'a> for AccessHashMap {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ps::array::ParseArrayLiteral;
-    use ps::build_powershell_tree;
-    use ps::forward::Forward;
-    use ps::integer::ParseInt;
-    use ps::string::ParseString;
+    use crate::ps::array::ParseArrayLiteral;
+    use crate::ps::build_powershell_tree;
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::ParseInt;
+    use crate::ps::string::ParseString;
 
     #[test]
     fn test_access_string_element_from_int() {

--- a/src/ps/access.rs
+++ b/src/ps/access.rs
@@ -40,7 +40,6 @@ fn get_array_at_index(s: &Vec<Value>, index: i64) -> Option<&Value> {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -190,7 +189,6 @@ impl<'a> RuleMut<'a> for AccessArray {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/access.rs
+++ b/src/ps/access.rs
@@ -38,9 +38,6 @@ fn get_array_at_index(s: &Vec<Value>, index: i64) -> Option<&Value> {
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::ParseInt;
@@ -187,9 +184,6 @@ impl<'a> RuleMut<'a> for AccessArray {
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::{ParseInt, AddInt};

--- a/src/ps/array.rs
+++ b/src/ps/array.rs
@@ -1,9 +1,9 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::{Array, Raw};
-use ps::Value::Num;
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Array, Raw};
+use crate::ps::Value::Num;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// Parse array literal
 ///
@@ -325,14 +325,14 @@ impl<'a> RuleMut<'a> for AddArray {
 
 #[cfg(test)]
 mod test {
-    use ps::access::AccessString;
-    use ps::array::{AddArray, ComputeArrayExpr, ParseArrayLiteral, ParseRange};
-    use ps::build_powershell_tree;
-    use ps::forward::Forward;
-    use ps::integer::{AddInt, ParseInt};
-    use ps::string::ParseString;
-    use ps::Powershell::Array;
-    use ps::Value::{Num, Str};
+    use crate::ps::access::AccessString;
+    use crate::ps::array::{AddArray, ComputeArrayExpr, ParseArrayLiteral, ParseRange};
+    use crate::ps::build_powershell_tree;
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::{AddInt, ParseInt};
+    use crate::ps::string::ParseString;
+    use crate::ps::Powershell::Array;
+    use crate::ps::Value::{Num, Str};
 
     #[test]
     fn test_init_num_array() {

--- a/src/ps/array.rs
+++ b/src/ps/array.rs
@@ -13,7 +13,6 @@ use crate::tree::{ControlFlow, NodeMut};
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -80,7 +79,6 @@ impl<'a> RuleMut<'a> for ParseArrayLiteral {
 /// # Example
 /// ```
 /// extern crate tree_sitter;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -166,7 +164,6 @@ impl<'a> RuleMut<'a> for ParseRange {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -250,7 +247,6 @@ impl<'a> RuleMut<'a> for ComputeArrayExpr {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/array.rs
+++ b/src/ps/array.rs
@@ -11,9 +11,6 @@ use crate::tree::{ControlFlow, NodeMut};
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::ParseInt;

--- a/src/ps/bool.rs
+++ b/src/ps/bool.rs
@@ -1,9 +1,9 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::Raw;
-use ps::Value::{Bool, Num, Str};
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::Raw;
+use crate::ps::Value::{Bool, Num, Str};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// This rule will infer boolean variable $true $false
 ///
@@ -372,13 +372,13 @@ impl<'a> RuleMut<'a> for Not {
 
 #[cfg(test)]
 mod test {
-    use ps::bool::{BoolAlgebra, Comparison, ParseBool};
-    use ps::build_powershell_tree;
-    use ps::forward::Forward;
-    use ps::integer::ParseInt;
-    use ps::string::ParseString;
-    use ps::Powershell::Raw;
-    use ps::Value::Bool;
+    use crate::ps::bool::{BoolAlgebra, Comparison, ParseBool};
+    use crate::ps::build_powershell_tree;
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::ParseInt;
+    use crate::ps::string::ParseString;
+    use crate::ps::Powershell::Raw;
+    use crate::ps::Value::Bool;
 
     #[test]
     fn test_parse_bool_true() {

--- a/src/ps/bool.rs
+++ b/src/ps/bool.rs
@@ -255,8 +255,8 @@ impl<'a> RuleMut<'a> for Comparison {
                     // Str and bool comparison
                     (Some(Raw(Str(left_value))), "-eq", Some(Raw(Bool(right_value)))) => {
                         node.set(Raw(Bool(
-                            (left_value.to_lowercase() == "true" && *right_value == true)
-                                || (left_value.to_lowercase() == "false" && *right_value == false),
+                            (left_value.to_lowercase() == "true" && *right_value)
+                                || (left_value.to_lowercase() == "false" && !(*right_value)),
                         )))
                     }
                     (Some(Raw(Bool(left_value))), "-eq", Some(Raw(Str(right_value)))) => {
@@ -267,8 +267,8 @@ impl<'a> RuleMut<'a> for Comparison {
                     }
                     (Some(Raw(Str(left_value))), "-ne", Some(Raw(Bool(right_value)))) => {
                         node.set(Raw(Bool(
-                            !((left_value.to_lowercase() == "true" && *right_value == true)
-                                || (left_value.to_lowercase() == "false" && *right_value == false)),
+                            !((left_value.to_lowercase() == "true" && *right_value)
+                                || (left_value.to_lowercase() == "false" && !(*right_value))),
                         )))
                     }
                     (Some(Raw(Bool(left_value))), "-ne", Some(Raw(Str(right_value)))) => {
@@ -285,7 +285,7 @@ impl<'a> RuleMut<'a> for Comparison {
                     (Some(Raw(Bool(true))), "-ge", Some(Raw(Str(_)))) => node.set(Raw(Bool(true))),
                     (Some(Raw(Bool(false))), "-gt", Some(Raw(_))) => node.set(Raw(Bool(false))),
                     (Some(Raw(Bool(false))), "-ge", Some(Raw(Str(right_value)))) => {
-                        node.set(Raw(Bool(right_value.len() == 0)))
+                        node.set(Raw(Bool(right_value.is_empty())))
                     }
 
                     // String to number comparison

--- a/src/ps/bool.rs
+++ b/src/ps/bool.rs
@@ -10,9 +10,6 @@ use crate::tree::{ControlFlow, NodeMut};
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/bool.rs
+++ b/src/ps/bool.rs
@@ -12,7 +12,6 @@ use crate::tree::{ControlFlow, NodeMut};
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -70,7 +69,6 @@ impl<'a> RuleMut<'a> for ParseBool {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -140,7 +138,6 @@ impl<'a> RuleMut<'a> for BoolAlgebra {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;

--- a/src/ps/cast.rs
+++ b/src/ps/cast.rs
@@ -16,7 +16,6 @@ pub struct Cast;
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/cast.rs
+++ b/src/ps/cast.rs
@@ -14,9 +14,6 @@ pub struct Cast;
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::ParseInt;

--- a/src/ps/cast.rs
+++ b/src/ps/cast.rs
@@ -172,8 +172,7 @@ impl<'a> RuleMut<'a> for Cast {
                         }
                         _ => ()
                     }
-                } else {
-                }
+                } 
             }
 
             // Forward inferred type in case of cast expression

--- a/src/ps/cast.rs
+++ b/src/ps/cast.rs
@@ -1,9 +1,9 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::{Array, PSItem, Raw, Type};
-use ps::Value::{Bool, Num, Str};
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Array, PSItem, Raw, Type};
+use crate::ps::Value::{Bool, Num, Str};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// Handle static cast operations
 /// For example [char]0x74 => 't'
@@ -228,16 +228,16 @@ impl<'a> RuleMut<'a> for CastNull {
 
 #[cfg(test)]
 mod test {
-    use ps::array::ParseArrayLiteral;
-    use ps::build_powershell_tree;
-    use ps::cast::Cast;
-    use ps::foreach::{ForEach, PSItemInferrator};
-    use ps::forward::Forward;
-    use ps::integer::{AddInt, ParseInt};
-    use ps::string::{ConcatString, ParseString};
-    use ps::typing::ParseType;
-    use ps::Powershell::{Array, Raw};
-    use ps::Value::{Num, Str};
+    use crate::ps::array::ParseArrayLiteral;
+    use crate::ps::build_powershell_tree;
+    use crate::ps::cast::Cast;
+    use crate::ps::foreach::{ForEach, PSItemInferrator};
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::{AddInt, ParseInt};
+    use crate::ps::string::{ConcatString, ParseString};
+    use crate::ps::typing::ParseType;
+    use crate::ps::Powershell::{Array, Raw};
+    use crate::ps::Value::{Num, Str};
 
     #[test]
     fn test_cast_int_to_char() {

--- a/src/ps/foreach.rs
+++ b/src/ps/foreach.rs
@@ -31,17 +31,15 @@ fn find_previous_expr<'a>(
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-/// use minusone::ps::build_powershell_tree;
-/// use minusone::ps::forward::Forward;
-/// use minusone::ps::integer::ParseInt;
-/// use minusone::ps::linter::Linter;
-/// use minusone::ps::cast::Cast;
-/// use minusone::ps::foreach::{PSItemInferrator, ForEach};
-/// use minusone::ps::join::JoinOperator;
-/// use minusone::ps::array::ParseArrayLiteral;
-/// use minusone::ps::typing::ParseType;
+/// # use minusone::ps::build_powershell_tree;
+/// # use minusone::ps::forward::Forward;
+/// # use minusone::ps::integer::ParseInt;
+/// # use minusone::ps::linter::Linter;
+/// # use minusone::ps::cast::Cast;
+/// # use minusone::ps::foreach::{PSItemInferrator, ForEach};
+/// # use minusone::ps::join::JoinOperator;
+/// # use minusone::ps::array::ParseArrayLiteral;
+/// # use minusone::ps::typing::ParseType;
 ///
 /// let mut tree = build_powershell_tree("-join ((0x61, 0x62, 0x63)|% {[char]$_})").unwrap();
 /// tree.apply_mut(&mut (
@@ -114,8 +112,6 @@ impl<'a> RuleMut<'a> for PSItemInferrator {
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::ParseInt;

--- a/src/ps/foreach.rs
+++ b/src/ps/foreach.rs
@@ -167,8 +167,8 @@ impl<'a> RuleMut<'a> for ForEach {
     ) -> MinusOneResult<()> {
         let view = node.view();
         // find usage of magic variable
-        if view.kind() == "foreach_command" {
-            if view.child_count() == 2 && view.child(1).unwrap().kind() == "script_block_expression"
+        if view.kind() == "foreach_command"
+            && view.child_count() == 2 && view.child(1).unwrap().kind() == "script_block_expression"
             {
                 let script_block_expression = view.child(1).unwrap();
                 if let Some(previous_command) = find_previous_expr(&view.parent().unwrap())? {
@@ -225,7 +225,6 @@ impl<'a> RuleMut<'a> for ForEach {
                     }
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/ps/foreach.rs
+++ b/src/ps/foreach.rs
@@ -1,8 +1,8 @@
-use error::{Error, MinusOneResult};
-use ps::Powershell;
-use ps::Powershell::{Array, PSItem, Raw};
-use rule::RuleMut;
-use tree::{ControlFlow, Node, NodeMut};
+use crate::error::{Error, MinusOneResult};
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Array, PSItem, Raw};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, Node, NodeMut};
 
 fn find_previous_expr<'a>(
     command: &Node<'a, Powershell>,
@@ -237,16 +237,16 @@ impl<'a> RuleMut<'a> for ForEach {
 
 #[cfg(test)]
 mod test {
-    use ps::array::ParseArrayLiteral;
-    use ps::build_powershell_tree;
-    use ps::cast::Cast;
-    use ps::foreach::{ForEach, PSItemInferrator};
-    use ps::forward::Forward;
-    use ps::integer::ParseInt;
-    use ps::string::ParseString;
-    use ps::typing::ParseType;
-    use ps::Powershell::Array;
-    use ps::Value::{Num, Str};
+    use crate::ps::array::ParseArrayLiteral;
+    use crate::ps::build_powershell_tree;
+    use crate::ps::cast::Cast;
+    use crate::ps::foreach::{ForEach, PSItemInferrator};
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::ParseInt;
+    use crate::ps::string::ParseString;
+    use crate::ps::typing::ParseType;
+    use crate::ps::Powershell::Array;
+    use crate::ps::Value::{Num, Str};
 
     #[test]
     fn test_foreach_transparent() {

--- a/src/ps/foreach.rs
+++ b/src/ps/foreach.rs
@@ -33,8 +33,6 @@ fn find_previous_expr<'a>(
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::ParseInt;
@@ -118,8 +116,6 @@ impl<'a> RuleMut<'a> for PSItemInferrator {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::integer::ParseInt;

--- a/src/ps/forward.rs
+++ b/src/ps/forward.rs
@@ -16,7 +16,6 @@ pub struct Forward;
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;

--- a/src/ps/forward.rs
+++ b/src/ps/forward.rs
@@ -1,8 +1,8 @@
-use error::{Error, MinusOneResult};
-use ps::Powershell;
-use ps::Powershell::Null;
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::{Error, MinusOneResult};
+use crate::ps::Powershell;
+use crate::ps::Powershell::Null;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// The forward rule is use to forward
 /// inferedtype in the most simple case : where there is nothing to do

--- a/src/ps/forward.rs
+++ b/src/ps/forward.rs
@@ -14,9 +14,6 @@ pub struct Forward;
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/hash.rs
+++ b/src/ps/hash.rs
@@ -1,10 +1,10 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::{HashEntry, HashMap, Raw};
-use ps::Value::Str;
-use rule::RuleMut;
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::{HashEntry, HashMap, Raw};
+use crate::ps::Value::Str;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 use std::collections::BTreeMap;
-use tree::{ControlFlow, NodeMut};
 
 #[derive(Default)]
 pub struct ParseHash;

--- a/src/ps/integer.rs
+++ b/src/ps/integer.rs
@@ -10,8 +10,6 @@ use crate::tree::{ControlFlow, NodeMut};
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/integer.rs
+++ b/src/ps/integer.rs
@@ -1,9 +1,9 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::Raw;
-use ps::Value::Num;
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::Raw;
+use crate::ps::Value::Num;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// Parse int will interpret integer node into Rust world
 /// as decimal
@@ -215,8 +215,8 @@ impl<'a> RuleMut<'a> for MultInt {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ps::build_powershell_tree;
-    use ps::forward::Forward;
+    use crate::ps::build_powershell_tree;
+    use crate::ps::forward::Forward;
 
     #[test]
     fn test_add_two_elements() {

--- a/src/ps/integer.rs
+++ b/src/ps/integer.rs
@@ -12,8 +12,6 @@ use crate::tree::{ControlFlow, NodeMut};
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -83,8 +81,6 @@ impl<'a> RuleMut<'a> for ParseInt {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -151,8 +147,6 @@ impl<'a> RuleMut<'a> for AddInt {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/join.rs
+++ b/src/ps/join.rs
@@ -64,20 +64,17 @@ impl<'a> RuleMut<'a> for JoinComparison {
             if let (Some(left_expression), Some(operator), Some(right_expression)) =
                 (view.child(0), view.child(1), view.child(2))
             {
-                match (
+                if let (Some(Array(src_array)), "-join", Some(Raw(Str(join_token)))) = (
                     left_expression.data(),
                     operator.text()?.to_lowercase().as_str(),
                     right_expression.data(),
                 ) {
-                    (Some(Array(src_array)), "-join", Some(Raw(Str(join_token)))) => {
-                        let result = src_array
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<String>>()
-                            .join(join_token);
-                        node.set(Raw(Str(result)));
-                    }
-                    _ => (),
+                    let result = src_array
+                        .iter()
+                        .map(|e| e.to_string())
+                        .collect::<Vec<String>>()
+                        .join(join_token);
+                    node.set(Raw(Str(result)));
                 }
             }
         }
@@ -240,20 +237,17 @@ impl<'a> RuleMut<'a> for JoinOperator {
         let view = node.view();
         if view.kind() == "expression_with_unary_operator" {
             if let (Some(operator), Some(unary_expression)) = (view.child(0), view.child(1)) {
-                match (
+                if let ("-join", Some(Array(values))) = (
                     operator.text()?.to_lowercase().as_str(),
                     unary_expression.data(),
                 ) {
-                    ("-join", Some(Array(values))) => {
-                        let result = values
-                            .iter()
-                            .map(|e| e.to_string())
-                            .collect::<Vec<String>>()
-                            .join(""); // by default the join operator join with an empty token
+                    let result = values
+                        .iter()
+                        .map(|e| e.to_string())
+                        .collect::<Vec<String>>()
+                        .join(""); // by default the join operator join with an empty token
 
-                        node.set(Raw(Str(result)));
-                    }
-                    _ => (),
+                    node.set(Raw(Str(result)));
                 }
             }
         }

--- a/src/ps/join.rs
+++ b/src/ps/join.rs
@@ -1,9 +1,9 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::{Array, Raw, Type};
-use ps::Value::Str;
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Array, Raw, Type};
+use crate::ps::Value::Str;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 /// This rule will infer the -join opoerator
 /// in the context of comparison operator

--- a/src/ps/join.rs
+++ b/src/ps/join.rs
@@ -12,9 +12,6 @@ use crate::tree::{ControlFlow, NodeMut};
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/join.rs
+++ b/src/ps/join.rs
@@ -14,7 +14,6 @@ use crate::tree::{ControlFlow, NodeMut};
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -94,7 +93,6 @@ impl<'a> RuleMut<'a> for JoinComparison {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -197,7 +195,6 @@ impl<'a> RuleMut<'a> for JoinStringMethod {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;

--- a/src/ps/linter.rs
+++ b/src/ps/linter.rs
@@ -340,12 +340,6 @@ impl<'a> Rule<'a> for Linter {
     }
 }
 
-impl Default for Linter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Linter {
     pub fn new() -> Self {
         Linter {
@@ -405,12 +399,6 @@ pub struct RemoveCode {
     last_index: usize,
 }
 
-impl Default for RemoveCode {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RemoveCode {
     pub fn new() -> Self {
         Self {
@@ -442,12 +430,6 @@ impl RemoveCode {
 
 pub struct RemoveComment {
     manager: RemoveCode
-}
-
-impl Default for RemoveComment {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl RemoveComment {

--- a/src/ps/linter.rs
+++ b/src/ps/linter.rs
@@ -1,12 +1,12 @@
-use error::MinusOneResult;
-use ps::{Powershell};
-use ps::Powershell::Raw;
-use ps::Value::{Bool, Num, Str};
-use regex::Regex;
-use ps::tool::StringTool;
-use ps::var::{find_variable_node, UnusedVar, Var};
-use rule::Rule;
-use tree::Node;
+use crate::error::MinusOneResult;
+use crate::ps::{Powershell};
+use crate::ps::Powershell::Raw;
+use crate::ps::Value::{Bool, Num, Str};
+use crate::regex::Regex;
+use crate::ps::tool::StringTool;
+use crate::ps::var::{find_variable_node, UnusedVar, Var};
+use crate::rule::Rule;
+use crate::tree::Node;
 
 fn escape_string(src: &str) -> String {
     let mut result = String::new();

--- a/src/ps/method.rs
+++ b/src/ps/method.rs
@@ -11,9 +11,6 @@ use crate::tree::{ControlFlow, NodeMut};
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
 /// use minusone::ps::linter::Linter;

--- a/src/ps/method.rs
+++ b/src/ps/method.rs
@@ -13,7 +13,6 @@ use crate::tree::{ControlFlow, NodeMut, Node};
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -92,7 +91,6 @@ impl<'a> RuleMut<'a> for Length {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -209,7 +207,6 @@ impl<'a> RuleMut<'a> for DecodeBase64 {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;

--- a/src/ps/method.rs
+++ b/src/ps/method.rs
@@ -1,11 +1,11 @@
 use base64::{engine::general_purpose, Engine as _};
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::{Array, Raw, Type};
-use ps::tool::StringTool;
-use ps::Value::{Num, Str};
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Array, Raw, Type, PSItem};
+use crate::ps::tool::StringTool;
+use crate::ps::Value::{Num, Str};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut, Node};
 
 /// Compute the length of predictable Array or string
 ///
@@ -380,15 +380,15 @@ impl<'a> RuleMut<'a> for FromUTF {
 
 #[cfg(test)]
 mod test {
-    use ps::array::{ComputeArrayExpr, ParseArrayLiteral};
-    use ps::build_powershell_tree;
-    use ps::forward::Forward;
-    use ps::integer::ParseInt;
-    use ps::method::{DecodeBase64, FromUTF, Length};
-    use ps::string::ParseString;
-    use ps::typing::ParseType;
-    use ps::Powershell::{Array, Raw};
-    use ps::Value::{Num, Str};
+    use crate::ps::array::{ComputeArrayExpr, ParseArrayLiteral};
+    use crate::ps::build_powershell_tree;
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::ParseInt;
+    use crate::ps::method::{DecodeBase64, FromUTF, Length};
+    use crate::ps::string::ParseString;
+    use crate::ps::typing::ParseType;
+    use crate::ps::Powershell::{Array, Raw};
+    use crate::ps::Value::{Num, Str};
 
     #[test]
     fn test_array_length() {

--- a/src/ps/mod.rs
+++ b/src/ps/mod.rs
@@ -1,24 +1,24 @@
-use error::{Error, MinusOneResult};
-use ps::access::{AccessArray, AccessHashMap, AccessString};
-use ps::array::{AddArray, ComputeArrayExpr, ParseArrayLiteral, ParseRange};
-use ps::bool::{BoolAlgebra, Comparison, Not, ParseBool};
-use ps::cast::{Cast, CastNull};
-use ps::foreach::{ForEach, PSItemInferrator};
-use ps::forward::Forward;
-use ps::hash::ParseHash;
-use ps::integer::{AddInt, MultInt, ParseInt};
-use ps::join::{JoinComparison, JoinOperator, JoinStringMethod};
-use ps::linter::RemoveComment;
-use ps::method::{DecodeBase64, FromUTF, Length};
-use ps::string::{
+use crate::error::{Error, MinusOneResult};
+use crate::ps::access::{AccessArray, AccessHashMap, AccessString};
+use crate::ps::array::{AddArray, ComputeArrayExpr, ParseArrayLiteral, ParseRange};
+use crate::ps::bool::{BoolAlgebra, Comparison, Not, ParseBool};
+use crate::ps::cast::{Cast, CastNull};
+use crate::ps::foreach::{ForEach, PSItemInferrator};
+use crate::ps::forward::Forward;
+use crate::ps::hash::ParseHash;
+use crate::ps::integer::{AddInt, MultInt, ParseInt};
+use crate::ps::join::{JoinComparison, JoinOperator, JoinStringMethod};
+use crate::ps::linter::RemoveComment;
+use crate::ps::method::{DecodeBase64, FromUTF, Length};
+use crate::ps::string::{
     ConcatString, FormatString, ParseString, StringReplaceMethod, StringReplaceOp,
     StringSplitMethod,
 };
-use ps::typing::ParseType;
-use ps::var::{StaticVar, Var};
-use std::collections::BTreeMap;
-use tree::{HashMapStorage, Storage, Tree};
+use crate::ps::typing::ParseType;
+use crate::ps::var::{StaticVar, Var};
+use crate::tree::{HashMapStorage, Storage, Tree};
 use tree_sitter_powershell::LANGUAGE as powershell_language;
+use std::collections::BTreeMap;
 
 pub mod access;
 pub mod array;

--- a/src/ps/mod.rs
+++ b/src/ps/mod.rs
@@ -158,14 +158,14 @@ pub fn remove_powershell_extra(source: &str) -> MinusOneResult<String> {
 
     let mut source_without_extra = RemoveComment::new();
     root.apply(&mut source_without_extra)?;
-    Ok(source_without_extra.clear()?)
+    source_without_extra.clear()
 }
 
-pub fn build_powershell_tree(source: &str) -> MinusOneResult<Tree<HashMapStorage<Powershell>>> {
+pub fn build_powershell_tree(source: &str) -> MinusOneResult<Tree<'_, HashMapStorage<Powershell>>> {
     build_powershell_tree_for_storage::<HashMapStorage<Powershell>>(source)
 }
 
-pub fn build_powershell_tree_for_storage<T: Storage + Default>(source: &str) -> MinusOneResult<Tree<T>> {
+pub fn build_powershell_tree_for_storage<T: Storage + Default>(source: &str) -> MinusOneResult<Tree<'_, T>> {
     let mut parser = tree_sitter::Parser::new();
     parser
         .set_language(&powershell_language.into())

--- a/src/ps/static.rs
+++ b/src/ps/static.rs
@@ -1,6 +1,6 @@
-use rule::RuleMut;
-use tree::{NodeMut, ControlFlow};
-use error::{MinusOneResult, Error};
+use crate::rule::RuleMut;
+use crate::tree::{NodeMut, ControlFlow};
+use crate::error::{MinusOneResult, Error};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PowershellDetect {

--- a/src/ps/strategy.rs
+++ b/src/ps/strategy.rs
@@ -1,10 +1,10 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::Raw;
-use ps::Value::Bool;
-use tree::BranchFlow::{Predictable, Unpredictable};
-use tree::ControlFlow::{Break, Continue};
-use tree::{ControlFlow, Node, Strategy};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::Raw;
+use crate::ps::Value::Bool;
+use crate::tree::BranchFlow::{Predictable, Unpredictable};
+use crate::tree::ControlFlow::{Break, Continue};
+use crate::tree::{ControlFlow, Node, Strategy};
 
 #[derive(Default)]
 pub struct PowershellStrategy;

--- a/src/ps/string.rs
+++ b/src/ps/string.rs
@@ -1,10 +1,10 @@
-use error::MinusOneResult;
-use ps::{Powershell};
-use ps::Powershell::{Array, Raw};
-use ps::tool::StringTool;
-use ps::Value::{Bool, Num, Str};
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::{Powershell};
+use crate::ps::Powershell::{Array, Raw};
+use crate::ps::tool::StringTool;
+use crate::ps::Value::{Bool, Num, Str};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 #[derive(Default)]
 pub struct ParseString;
@@ -374,12 +374,12 @@ impl<'a> RuleMut<'a> for StringSplitMethod {
 
 #[cfg(test)]
 mod test {
-    use ps::array::ParseArrayLiteral;
-    use ps::build_powershell_tree;
-    use ps::forward::Forward;
-    use ps::string::{ConcatString, FormatString, ParseString, StringReplaceOp};
-    use ps::Powershell::Raw;
-    use ps::Value::Str;
+    use crate::ps::array::ParseArrayLiteral;
+    use crate::ps::build_powershell_tree;
+    use crate::ps::forward::Forward;
+    use crate::ps::string::{ConcatString, FormatString, ParseString, StringReplaceOp};
+    use crate::ps::Powershell::Raw;
+    use crate::ps::Value::Str;
 
     #[test]
     fn test_concat_two_elements() {

--- a/src/ps/string.rs
+++ b/src/ps/string.rs
@@ -126,11 +126,8 @@ impl<'a> RuleMut<'a> for ConcatString {
             if let (Some(left_op), Some(operator), Some(right_op)) =
                 (view.child(0), view.child(1), view.child(2))
             {
-                match (left_op.data(), operator.text()?, right_op.data()) {
-                    (Some(Raw(Str(string_left))), "+", Some(Raw(Str(string_right)))) => {
-                        node.reduce(Raw(Str(String::from(string_left) + string_right)))
-                    }
-                    _ => {}
+                if let (Some(Raw(Str(string_left))), "+", Some(Raw(Str(string_right)))) = (left_op.data(), operator.text()?, right_op.data()) {
+                    node.reduce(Raw(Str(String::from(string_left) + string_right)))
                 }
             }
         }
@@ -225,7 +222,7 @@ impl<'a> RuleMut<'a> for StringReplaceOp {
                     (Some(Raw(Str(src))), "-replace", Some(Array(params)))
                     | (Some(Raw(Str(src))), "-creplace", Some(Array(params))) => {
                         // -replace operator need two params
-                        if let (Some(Str(old)), Some(Str(new))) = (params.get(0), params.get(1)) {
+                        if let (Some(Str(old)), Some(Str(new))) = (params.first(), params.get(1)) {
                             node.reduce(Raw(Str(src.replace(old, new))));
                         }
                     }
@@ -292,7 +289,7 @@ impl<'a> RuleMut<'a> for FormatString {
                         let mut result = format_str.clone();
                         for (index, new) in format_args.iter().enumerate() {
                             result = result.replace(
-                                format!("{{{}}}", index).as_str(),
+                                format!("{{{index}}}").as_str(),
                                 new.to_string().as_str(),
                             );
                         }

--- a/src/ps/string.rs
+++ b/src/ps/string.rs
@@ -87,7 +87,6 @@ impl<'a> RuleMut<'a> for ParseString {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -244,7 +243,6 @@ impl<'a> RuleMut<'a> for StringReplaceOp {
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;

--- a/src/ps/string.rs
+++ b/src/ps/string.rs
@@ -85,9 +85,6 @@ impl<'a> RuleMut<'a> for ParseString {
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;
@@ -238,9 +235,6 @@ impl<'a> RuleMut<'a> for StringReplaceOp {
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/tool.rs
+++ b/src/ps/tool.rs
@@ -23,7 +23,7 @@ impl StringTool for String {
     fn uppercase_first(self) -> String {
         let mut v = self.to_lowercase();
         let s = v.get_mut(0..1);
-        s.map(|s| s.make_ascii_uppercase());
+        if let Some(s) = s { s.make_ascii_uppercase() }
         v
     }
 

--- a/src/ps/typing.rs
+++ b/src/ps/typing.rs
@@ -1,8 +1,8 @@
-use error::MinusOneResult;
-use ps::Powershell;
-use ps::Powershell::Type;
-use rule::RuleMut;
-use tree::{ControlFlow, NodeMut};
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::Type;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
 
 #[derive(Default)]
 pub struct ParseType;

--- a/src/ps/var.rs
+++ b/src/ps/var.rs
@@ -17,7 +17,6 @@ use std::ops::Add;
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
@@ -642,7 +641,6 @@ fn assign_handler(
 /// ```
 /// extern crate tree_sitter;
 /// extern crate tree_sitter_powershell;
-/// extern crate minusone;
 ///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;

--- a/src/ps/var.rs
+++ b/src/ps/var.rs
@@ -15,9 +15,6 @@ use std::ops::Add;
 ///
 /// # Example
 /// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
 /// use minusone::tree::{HashMapStorage, Tree};
 /// use minusone::ps::build_powershell_tree;
 /// use minusone::ps::forward::Forward;

--- a/src/ps/var.rs
+++ b/src/ps/var.rs
@@ -152,7 +152,7 @@ impl Var {
             }
         }
 
-        return None;
+        None
     }
 
     /// Resolve the name of a variable pattern given the current scope
@@ -160,7 +160,7 @@ impl Var {
     /// Use for patterns used by variable, get-variable, set-variable, get-childitem...
     fn resolve_wildcarded(&self, variable_name: String) -> Option<String> {
         if variable_name.contains("*") {
-            let re = Regex::new(&*format!("^{}$", variable_name.replace("*", ".*"))).unwrap();
+            let re = Regex::new(&format!("^{}$", variable_name.replace("*", ".*"))).unwrap();
             let current_scope = self.scope_manager.current();
             let var_names = current_scope.get_var_names();
             let matches: Vec<_> = var_names
@@ -288,7 +288,7 @@ impl<'a> RuleMut<'a> for Var {
                                 (scope.get_var(&var_name), right.data())
                             {
                                 // disable anything from for_initializer
-                                if !view.get_parent_of_types(vec!["for_initializer"]).is_none() {
+                                if view.get_parent_of_types(vec!["for_initializer"]).is_some() {
                                     scope.forget(&var_name);
                                 } else {
                                     // only predictable assignment is handled of local var
@@ -566,18 +566,18 @@ fn assign_handler(
         // += operator
         (Some(Raw(Num(v))), "+=", Raw(Num(n))) => Some(Raw(Num(v + n))),
         (Some(Raw(Num(v))), "+=", Raw(Str(n))) => {
-            n.parse::<i64>().ok().and_then(|n| Some(Raw(Num(v + n))))
+            n.parse::<i64>().ok().map(|n| Raw(Num(v + n)))
         }
         (Some(Raw(Str(v))), "+=", Raw(Num(n))) => Some(Raw(Str(v.clone().add(&n.to_string())))),
-        (Some(Raw(Str(v))), "+=", Raw(Str(n))) => Some(Raw(Str(v.clone().add(&n)))),
+        (Some(Raw(Str(v))), "+=", Raw(Str(n))) => Some(Raw(Str(v.clone().add(n)))),
 
         // -= operator
         (Some(Raw(Num(v))), "-=", Raw(Num(n))) => Some(Raw(Num(v - n))),
         (Some(Raw(Num(v))), "-=", Raw(Str(n))) => {
-            n.parse::<i64>().ok().and_then(|n| Some(Raw(Num(v - n))))
+            n.parse::<i64>().ok().map(|n| Raw(Num(v - n)))
         }
         (Some(Raw(Str(v))), "-=", Raw(Num(n))) => {
-            v.parse::<i64>().ok().and_then(|v| Some(Raw(Num(v - n))))
+            v.parse::<i64>().ok().map(|v| Raw(Num(v - n)))
         }
         (Some(Raw(Str(v))), "-=", Raw(Str(n))) => {
             if let (Ok(v), Ok(n)) = (v.parse::<i64>(), n.parse::<i64>()) {
@@ -590,21 +590,20 @@ fn assign_handler(
         // *= operator
         (Some(Raw(Num(v))), "*=", Raw(Num(n))) => Some(Raw(Num(v * n))),
         (Some(Raw(Num(v))), "*=", Raw(Str(n))) => {
-            n.parse::<i64>().ok().and_then(|n| Some(Raw(Num(v * n))))
+            n.parse::<i64>().ok().map(|n| Raw(Num(v * n)))
         }
         (Some(Raw(Str(v))), "*=", Raw(Num(n))) => Some(Raw(Str(v.repeat(*n as usize)))),
         (Some(Raw(Str(v))), "*=", Raw(Str(n))) => n
             .parse::<usize>()
-            .ok()
-            .and_then(|n| Some(Raw(Str(v.repeat(n))))),
+            .ok().map(|n| Raw(Str(v.repeat(n)))),
 
         // /= operator
         (Some(Raw(Num(v))), "/=", Raw(Num(n))) => Some(Raw(Num(v / n))),
         (Some(Raw(Num(v))), "/=", Raw(Str(n))) => {
-            n.parse::<i64>().ok().and_then(|n| Some(Raw(Num(v / n))))
+            n.parse::<i64>().ok().map(|n| Raw(Num(v / n)))
         }
         (Some(Raw(Str(v))), "/=", Raw(Num(n))) => {
-            v.parse::<i64>().ok().and_then(|v| Some(Raw(Num(v / n))))
+            v.parse::<i64>().ok().map(|v| Raw(Num(v / n)))
         }
         (Some(Raw(Str(v))), "/=", Raw(Str(n))) => {
             if let (Ok(v), Ok(n)) = (v.parse::<i64>(), n.parse::<i64>()) {
@@ -617,10 +616,10 @@ fn assign_handler(
         // %= operator
         (Some(Raw(Num(v))), "%=", Raw(Num(n))) => Some(Raw(Num(v % n))),
         (Some(Raw(Num(v))), "%=", Raw(Str(n))) => {
-            n.parse::<i64>().ok().and_then(|n| Some(Raw(Num(v % n))))
+            n.parse::<i64>().ok().map(|n| Raw(Num(v % n)))
         }
         (Some(Raw(Str(v))), "%=", Raw(Num(n))) => {
-            v.parse::<i64>().ok().and_then(|v| Some(Raw(Num(v % n))))
+            v.parse::<i64>().ok().map(|v| Raw(Num(v % n)))
         }
         (Some(Raw(Str(v))), "%=", Raw(Str(n))) => {
             if let (Ok(v), Ok(n)) = (v.parse::<i64>(), n.parse::<i64>()) {

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,5 +1,5 @@
-use error::MinusOneResult;
-use tree::{ControlFlow, Node, NodeMut};
+use crate::error::MinusOneResult;
+use crate::tree::{ControlFlow, Node, NodeMut};
 
 pub trait RuleMut<'a> {
     type Language;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -22,12 +22,6 @@ pub struct Scope<T: Clone> {
     vars: HashMap<String, Variable<T>>,
 }
 
-impl<T: Clone> Default for Scope<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<T: Clone> Scope<T> {
     pub fn new() -> Self {
         Scope {
@@ -94,12 +88,6 @@ impl<T: Clone> Scope<T> {
 
 pub struct ScopeManager<T: Clone> {
     scopes: Vec<Scope<T>>,
-}
-
-impl<T: Clone> Default for ScopeManager<T> {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl<T: Clone> ScopeManager<T> {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -22,6 +22,12 @@ pub struct Scope<T: Clone> {
     vars: HashMap<String, Variable<T>>,
 }
 
+impl<T: Clone> Default for Scope<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Clone> Scope<T> {
     pub fn new() -> Self {
         Scope {
@@ -75,7 +81,7 @@ impl<T: Clone> Scope<T> {
     }
 
     pub fn get_var_names(&self) -> Vec<String> {
-        self.vars.clone().keys().map(|k| k.clone()).collect()
+        self.vars.clone().keys().cloned().collect()
     }
 
     pub fn is_local(&self, var_name: &str) -> Option<bool> {
@@ -88,6 +94,12 @@ impl<T: Clone> Scope<T> {
 
 pub struct ScopeManager<T: Clone> {
     scopes: Vec<Scope<T>>,
+}
+
+impl<T: Clone> Default for ScopeManager<T> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T: Clone> ScopeManager<T> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -83,8 +83,6 @@ impl<T> Storage for HashMapStorage<T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage};
@@ -110,8 +108,6 @@ impl<T> Storage for HashMapStorage<T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage};
@@ -138,8 +134,6 @@ impl<T> Storage for HashMapStorage<T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage};
@@ -203,8 +197,6 @@ impl<'a, T> NodeMut<'a, T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage, NodeMut};
@@ -233,8 +225,6 @@ impl<'a, T> NodeMut<'a, T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage, NodeMut};
@@ -264,8 +254,6 @@ impl<'a, T> NodeMut<'a, T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage, NodeMut};
@@ -297,8 +285,6 @@ impl<'a, T> NodeMut<'a, T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage, NodeMut, ControlFlow};
@@ -386,8 +372,6 @@ impl<'a, T> NodeMut<'a, T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
-    ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;
     /// use minusone::tree::{Storage, HashMapStorage, NodeMut, BranchFlow, ControlFlow, Strategy, Node};
@@ -475,7 +459,6 @@ impl<'a, T> NodeMut<'a, T> {
     /// ```
     /// extern crate tree_sitter;
     /// extern crate tree_sitter_powershell;
-    /// extern crate minusone;
     ///
     /// use tree_sitter::{Parser, Language};
     /// use tree_sitter_powershell::LANGUAGE as powershell_language;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,5 @@
-use error::MinusOneResult;
-use rule::{Rule, RuleMut};
+use crate::error::MinusOneResult;
+use crate::rule::{Rule, RuleMut};
 use std::collections::HashMap;
 use std::ops;
 use std::str::Utf8Error;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -215,7 +215,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///
     /// assert_eq!(node_view.kind(), "program");
     /// ```
-    pub fn view(&self) -> Node<T> {
+    pub fn view(&self) -> Node<'_, T> {
         Node::new(self.inner, self.source, self.storage)
     }
 
@@ -359,7 +359,7 @@ impl<'a, T> NodeMut<'a, T> {
 
                 // decrement number of children handled
                 if let Some(l) = stack.last_mut() {
-                    l.1 = l.1 - 1;
+                    l.1 -= 1;
                 }
             }
         }
@@ -560,7 +560,7 @@ impl<'a, T> NodeMut<'a, T> {
 
                 // decrement number of children handled
                 if let Some(l) = stack.last_mut() {
-                    l.1 = l.1 - 1;
+                    l.1 -= 1;
                 }
             }
         }
@@ -723,7 +723,7 @@ impl<'a, T> Node<'a, T> {
 
                 // decrement number of children handled
                 if let Some(l) = stack.last_mut() {
-                    l.1 = l.1 - 1;
+                    l.1 -= 1;
                 }
             }
         }
@@ -868,7 +868,7 @@ where
         node.apply(rule)
     }
 
-    pub fn root(&self) -> MinusOneResult<Node<S::Component>> {
+    pub fn root(&self) -> MinusOneResult<Node<'_, S::Component>> {
         Ok(Node::new(
             self.tree_sitter.root_node(),
             self.source,


### PR DESCRIPTION
Hello, thank you for all of the great work you've done on this project, and for resurrecting the tree-sitter-powershell grammar! I hope you don't mind me making some contributions.

When working on my fork, I noticed several compiler warnings, and my language server (`rust-analyzer 0.3.2490-standalone (9fc1b9076c 2025-06-08)`) was failing to resolve imports within the crate due to the use of relative imports. This PR:

- Converts relative imports to use the `crate::` prefix
- Removes unneeded uses of `extern crate` (see https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html)
- Adds 4 lifetime annotations for consistency and to remove compiler warnings
- Adds changes produced by `cargo clippy --fix`

The tests and the doctests are all passing after these changes, there are no more compiler warnings, and rust-analyzer understands the import structure.