### PR TITLE
Update tree-sitter-powershell to 0.25.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ minusone-cli = ["clap"]
 
 [dependencies]
 tree-sitter = "0.25"
-tree-sitter-powershell = "0.25.9"
+tree-sitter-powershell = "0.25.10"
 clap = { version = "^2.33", optional = true }
 base64 = "0.21.5"
 num = "0.4.3"

--- a/src/ps/array.rs
+++ b/src/ps/array.rs
@@ -661,6 +661,8 @@ mod test {
                 .unwrap()
                 .child(0)
                 .unwrap()
+                .child(0)
+                .unwrap()
                 .data()
                 .expect("Inferred data"),
             Array(vec![Num(0); 16]),

--- a/src/ps/foreach.rs
+++ b/src/ps/foreach.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, MinusOneResult};
+use crate::ps::tool::CommandTool;
 use crate::ps::Powershell;
 use crate::ps::Powershell::{Array, PSItem, Raw};
 use crate::rule::RuleMut;
@@ -84,20 +85,25 @@ impl<'a> RuleMut<'a> for PSItemInferrator {
             if let Some(script_block_expression) =
                 view.get_parent_of_types(vec!["script_block_expression"])
             {
-                if let Some(foreach_command) =
-                    script_block_expression.get_parent_of_types(vec!["foreach_command"])
+                if let Some(command) = script_block_expression.get_parent_of_types(vec!["command"])
                 {
-                    if let Some(previous) = find_previous_expr(&foreach_command.parent().unwrap())?
-                    {
-                        // the previous in the pipeline
-                        match previous.data() {
-                            Some(Array(values)) => {
-                                node.set(PSItem(values.clone()));
+                    if let Some(command_name) = command.child(0) {
+                        if matches!(
+                            command_name.text().unwrap(),
+                            "foreach" | "%" | "foreach-object"
+                        ) {
+                            if let Some(previous) = find_previous_expr(&command)? {
+                                // the previous in the pipeline
+                                match previous.data() {
+                                    Some(Array(values)) => {
+                                        node.set(PSItem(values.clone()));
+                                    }
+                                    Some(Raw(value)) => {
+                                        node.set(PSItem(vec![value.clone()]));
+                                    }
+                                    _ => (),
+                                }
                             }
-                            Some(Raw(value)) => {
-                                node.set(PSItem(vec![value.clone()]));
-                            }
-                            _ => (),
                         }
                     }
                 }
@@ -163,60 +169,66 @@ impl<'a> RuleMut<'a> for ForEach {
     ) -> MinusOneResult<()> {
         let view = node.view();
         // find usage of magic variable
-        if view.kind() == "foreach_command"
-            && view.child_count() == 2
-            && view.child(1).unwrap().kind() == "script_block_expression"
-        {
-            let script_block_expression = view.child(1).unwrap();
-            if let Some(previous_command) = find_previous_expr(&view.parent().unwrap())? {
-                // if the previous pipeline was inferred as an array
-                let mut previous_values = Vec::new();
-                match previous_command.data() {
-                    Some(Array(values)) => previous_values.extend(values.clone()),
-                    // array of size 1
-                    Some(Raw(value)) => previous_values.push(value.clone()),
-                    _ => (),
-                }
-                let script_block_body = script_block_expression
-                    .child(1)
-                    .ok_or(Error::invalid_child())? // script_block node
-                    .named_child("script_block_body");
+        if view.is_command() {
+            let args = view.get_command_args();
+            if matches!(
+                view.get_command_name().as_str(),
+                "foreach" | "foreach-object" | "%"
+            ) && args.len() == 1
+            {
+                let script_block_expression = args[0].smallest_child();
+                if script_block_expression.kind() == "script_block_expression" {
+                    if let Some(previous_command) = find_previous_expr(&view)? {
+                        // if the previous pipeline was inferred as an array
+                        let mut previous_values = Vec::new();
+                        match previous_command.data() {
+                            Some(Array(values)) => previous_values.extend(values.clone()),
+                            // array of size 1
+                            Some(Raw(value)) => previous_values.push(value.clone()),
+                            _ => (),
+                        }
+                        let script_block_body = script_block_expression
+                            .child(1)
+                            .ok_or(Error::invalid_child())? // script_block node
+                            .named_child("script_block_body");
 
-                if let Some(script_block_body_node) = script_block_body {
-                    if let Some(statement_list) =
-                        script_block_body_node.named_child("statement_list")
-                    {
-                        // determine the number of loop
-                        // by looping over the size of the array
+                        if let Some(script_block_body_node) = script_block_body {
+                            if let Some(statement_list) =
+                                script_block_body_node.named_child("statement_list")
+                            {
+                                // determine the number of loop
+                                // by looping over the size of the array
 
-                        let mut result = Vec::new();
-                        for i in 0..previous_values.len() {
-                            for child_statement in statement_list.iter() {
-                                if child_statement.kind() == "empty_statement" {
-                                    continue;
-                                }
+                                let mut result = Vec::new();
+                                for i in 0..previous_values.len() {
+                                    for child_statement in statement_list.iter() {
+                                        if child_statement.kind() == "empty_statement" {
+                                            continue;
+                                        }
 
-                                match child_statement.data() {
-                                    Some(PSItem(values)) => {
-                                        result.push(values[i].clone());
-                                    }
-                                    Some(Raw(r)) => {
-                                        result.push(r.clone());
-                                    }
-                                    Some(Array(array_value)) => {
-                                        for v in array_value {
-                                            result.push(v.clone());
+                                        match child_statement.data() {
+                                            Some(PSItem(values)) => {
+                                                result.push(values[i].clone());
+                                            }
+                                            Some(Raw(r)) => {
+                                                result.push(r.clone());
+                                            }
+                                            Some(Array(array_value)) => {
+                                                for v in array_value {
+                                                    result.push(v.clone());
+                                                }
+                                            }
+                                            _ => {
+                                                // stop inferring we have not enough infos
+                                                return Ok(());
+                                            }
                                         }
                                     }
-                                    _ => {
-                                        // stop inferring we have not enough infos
-                                        return Ok(());
-                                    }
+                                }
+                                if !result.is_empty() {
+                                    node.set(Array(result));
                                 }
                             }
-                        }
-                        if !result.is_empty() {
-                            node.set(Array(result));
                         }
                     }
                 }

--- a/src/ps/forward.rs
+++ b/src/ps/forward.rs
@@ -1,3 +1,5 @@
+use std::process::Child;
+
 use crate::error::{Error, MinusOneResult};
 use crate::ps::Powershell;
 use crate::ps::Powershell::Null;
@@ -103,23 +105,28 @@ impl<'a> RuleMut<'a> for Forward {
                 }
             }
 
-            // we infer pipeline type with the value of the last expression
-            "pipeline" => {
+            // we infer pipeline chain type with the value of the last expression
+            "pipeline_chain" => {
                 if let Some(expression) = view.child(view.child_count() - 1) {
                     if let Some(expression_data) = expression.data() {
                         node.set(expression_data.clone())
                     }
                 }
             }
-            "command" => {
-                if let Some(sub_command) = view.child(0) {
-                    if sub_command.kind() == "foreach_command" {
-                        if let Some(expression_data) = sub_command.data() {
-                            node.reduce(expression_data.clone())
+
+            // we infer pipeline only if there is one pipeline_chain child
+            "pipeline" => {
+                if view.child_count() == 1 {
+                    if let Some(child) = view.child(0) {
+                        if child.kind() == "pipeline_chain" {
+                            if let Some(expression_data) = child.data() {
+                                node.set(expression_data.clone())
+                            }
                         }
                     }
                 }
             }
+
             "type_literal" => {
                 if let Some(expression) = view.child(1) {
                     if let Some(expression_data) = expression.data() {

--- a/src/ps/tool.rs
+++ b/src/ps/tool.rs
@@ -1,3 +1,5 @@
+use crate::{ps::Powershell, tree::Node};
+
 pub trait StringTool {
     fn remove_tilt(self) -> Self;
     fn remove_quote(self) -> Self;
@@ -30,5 +32,39 @@ impl StringTool for String {
 
     fn normalize(self) -> Self {
         self.to_lowercase().remove_tilt().remove_quote()
+    }
+}
+
+pub trait CommandTool<'a> {
+    fn is_command(&self) -> bool;
+    fn get_command_name(&self) -> String;
+    fn get_command_args(&self) -> Vec<Node<'a, Powershell>>;
+    fn get_command_params(&self) -> Vec<Node<'a, Powershell>>;
+}
+
+impl<'a> CommandTool<'a> for Node<'a, Powershell> {
+    fn is_command(&self) -> bool {
+        self.kind() == "command"
+    }
+
+    fn get_command_name(&self) -> String {
+        self.child(0).unwrap().text().unwrap().to_owned()
+    }
+
+    fn get_command_args(&self) -> Vec<Node<'a, Powershell>> {
+        self.child(1)
+            .unwrap()
+            .iter()
+            .filter(|n| n.kind() != "command_argument_sep" && n.kind() != "command_parameter")
+            .collect()
+    }
+
+    fn get_command_params(&self) -> Vec<Node<'a, Powershell>> {
+        self.child(1)
+            .unwrap()
+            .iter()
+            .skip(1)
+            .filter(|n| n.kind() == "command_parameter")
+            .collect()
     }
 }

--- a/src/ps/var.rs
+++ b/src/ps/var.rs
@@ -743,6 +743,8 @@ mod test {
                 .child(1)
                 .unwrap() // pipeline
                 .child(0)
+                .unwrap() // pipeline chain
+                .child(0)
                 .unwrap() //command
                 .child(1)
                 .unwrap() // command_elements
@@ -780,6 +782,8 @@ mod test {
                 .unwrap() // statement_list
                 .child(1)
                 .unwrap() // pipeline
+                .child(0)
+                .unwrap() // pipeline chain
                 .child(0)
                 .unwrap() //command
                 .child(1)
@@ -848,6 +852,8 @@ mod test {
                 .child(2)
                 .unwrap() // pipeline
                 .child(0)
+                .unwrap() // pipeline chain
+                .child(0)
                 .unwrap() //command
                 .child(1)
                 .unwrap() // command_elements
@@ -892,6 +898,8 @@ mod test {
                 .unwrap() // statement_list
                 .child(2)
                 .unwrap() // pipeline
+                .child(0)
+                .unwrap() // pipeline chain
                 .child(0)
                 .unwrap() //command
                 .child(1)
@@ -938,6 +946,8 @@ mod test {
                 .unwrap() // statement_list
                 .child(2)
                 .unwrap() // pipeline
+                .child(0)
+                .unwrap() // pipeline chain
                 .child(0)
                 .unwrap() //command
                 .child(1)
@@ -987,6 +997,8 @@ mod test {
                 .child(2)
                 .unwrap() // pipeline
                 .child(0)
+                .unwrap() // pipeline chain
+                .child(0)
                 .unwrap() //command
                 .child(1)
                 .unwrap() // command_elements
@@ -1032,6 +1044,8 @@ mod test {
                 .child(2)
                 .unwrap() // pipeline
                 .child(0)
+                .unwrap() // pipeline chain
+                .child(0)
                 .unwrap() //command
                 .child(1)
                 .unwrap() // command_elements
@@ -1076,6 +1090,8 @@ mod test {
                 .child(2)
                 .unwrap() // pipeline
                 .child(0)
+                .unwrap() // pipeline chain
+                .child(0)
                 .unwrap() //command
                 .child(1)
                 .unwrap() // command_elements
@@ -1119,6 +1135,8 @@ mod test {
                 .unwrap() // statement_list
                 .child(2)
                 .unwrap() // pipeline
+                .child(0)
+                .unwrap() // pipeline chain
                 .child(0)
                 .unwrap() //command
                 .child(1)
@@ -1167,6 +1185,8 @@ mod test {
                 .child(2)
                 .unwrap() // pipeline
                 .child(0)
+                .unwrap() // pipeline chain
+                .child(0)
                 .unwrap() //command
                 .child(1)
                 .unwrap() // command_elements
@@ -1213,6 +1233,8 @@ mod test {
                 .unwrap() // statement_list
                 .child(2)
                 .unwrap() // pipeline
+                .child(0)
+                .unwrap() // pipeline chain
                 .child(0)
                 .unwrap() //command
                 .child(1)
@@ -2181,6 +2203,8 @@ mod test {
                 .unwrap() // statement_list
                 .child(3)
                 .unwrap() // Write-Host pipeline
+                .child(0)
+                .unwrap() // pipeline_chain
                 .child(0)
                 .unwrap() // Write-host command
                 .named_child("command_elements")


### PR DESCRIPTION
- Update the tree-sitter-powershell version
- Fix the tests
- Update the `foreach_command` node that is deprecated