### PR TITLE
Add miri deps

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -25,6 +25,7 @@
         "rustc"
         "rust-analyzer"
         "clippy"
+        "miri"
       ];
       targets = [
         "wasm32-wasip1"


### PR DESCRIPTION
Tests are failing because miri module is missing in cargo
Not sure why gh action runners need it because I don't need it locally but let's try to make it happy :shrug: 