### PR TITLE
Recursion system + JS fn call with this system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +641,7 @@ version = "0.5.0"
 dependencies = [
  "base64",
  "colored",
+ "dyn-clone",
  "log",
  "num",
  "num-bigint",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,3 +28,4 @@ log = { workspace = true }
 regex = "1.11.1"
 colored = "3"
 num-bigint = "0.4.6"
+dyn-clone = "1.0.20"

--- a/core/src/debug.rs
+++ b/core/src/debug.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 
 /// A debug view is used to print the tree nodes
 /// with associated inferred type
+#[derive(Clone)]
 pub struct DebugView<T> {
     tab_depth: u32,
     tab_size: u32,

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -51,6 +51,7 @@ impl<'a, B: DeobfuscationBackend> DeobfuscateEngine<'a, B> {
     pub fn debug(&self, custom_debug_view: Option<DebugView<B::Language>>)
     where
         B::Language: Debug,
+        <B as DeobfuscationBackend>::Language: Clone,
     {
         let mut debug_view = custom_debug_view.unwrap_or_else(DebugView::default);
         self.root.apply(&mut debug_view).unwrap();

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -10,7 +10,7 @@ use crate::tree::{ControlFlow, NodeMut};
 use log::{trace, warn};
 
 /// Parses JavaScript array literals into `Array(_)`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseArray;
 
 impl<'a> RuleMut<'a> for ParseArray {
@@ -68,7 +68,7 @@ impl<'a> RuleMut<'a> for ParseArray {
 /// assert_eq!(linter.output, "var x = '1,23,4'");
 /// ```
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CombineArrays;
 
 impl<'a> RuleMut<'a> for CombineArrays {
@@ -214,7 +214,7 @@ impl<'a> RuleMut<'a> for CombineArrays {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = [2, '3'];");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct GetArrayElement;
 
 impl GetArrayElement {
@@ -410,7 +410,7 @@ fn combine_arrays(left: &Vec<JavaScript>, right: &Vec<JavaScript>) -> String {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 455;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ArrayPlusMinus;
 
 impl<'a> RuleMut<'a> for ArrayPlusMinus {
@@ -498,7 +498,7 @@ fn recursive_array_number_extraction(arr: &Vec<JavaScript>) -> Option<f64> {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 'a,b';");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ArrayJoin;
 
 impl<'a> RuleMut<'a> for ArrayJoin {

--- a/core/src/js/b64.rs
+++ b/core/src/js/b64.rs
@@ -25,7 +25,7 @@ use log::{trace, warn};
 ///
 /// assert_eq!(linter.output, "var x = 'minusone';");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct B64;
 
 impl<'a> RuleMut<'a> for B64 {

--- a/core/src/js/bool.rs
+++ b/core/src/js/bool.rs
@@ -9,7 +9,7 @@ use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
 
 /// Parses JavaScript numeric literals (decimal, hex, octal, binary) into `Raw(Num(_))`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseBool;
 
 impl<'a> RuleMut<'a> for ParseBool {
@@ -57,7 +57,7 @@ impl<'a> RuleMut<'a> for ParseBool {
 /// assert_eq!(linter.output, "var x = false;");
 /// ```
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NotBool;
 
 impl<'a> RuleMut<'a> for NotBool {
@@ -121,7 +121,7 @@ impl<'a> RuleMut<'a> for NotBool {
 ///
 /// assert_eq!(linter.output, "var x = true;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BoolAlgebra;
 
 impl<'a> RuleMut<'a> for BoolAlgebra {
@@ -181,7 +181,7 @@ impl<'a> RuleMut<'a> for BoolAlgebra {
 /// assert_eq!(linter.output, "var x = 0;");
 /// ```
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AddBool;
 
 impl<'a> RuleMut<'a> for AddBool {
@@ -282,7 +282,7 @@ impl<'a> RuleMut<'a> for AddBool {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 1; var y = 0;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BoolPlusMinus;
 
 impl<'a> RuleMut<'a> for BoolPlusMinus {

--- a/core/src/js/comparator.rs
+++ b/core/src/js/comparator.rs
@@ -28,7 +28,7 @@ use std::cmp::Ordering::*;
 ///
 /// assert_eq!(linter.output, "var x = true;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StrictEq;
 
 impl<'a> RuleMut<'a> for StrictEq {
@@ -142,7 +142,7 @@ impl<'a> RuleMut<'a> for StrictEq {
 ///
 /// assert_eq!(linter.output, "var x = true;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct LooseEq;
 
 impl<'a> RuleMut<'a> for LooseEq {
@@ -291,7 +291,7 @@ fn parse_js_bigint(s: &str) -> Option<num_bigint::BigInt> {
 ///
 /// assert_eq!(linter.output, "var x = true;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CmpOrd;
 
 impl<'a> RuleMut<'a> for CmpOrd {

--- a/core/src/js/deadcode.rs
+++ b/core/src/js/deadcode.rs
@@ -5,7 +5,7 @@ use log::trace;
 use std::collections::HashMap;
 
 /// Tracks which JavaScript identifiers are actually read (used) vs only written to (declared/assigned).
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct UnusedVar {
     reads: HashMap<String, bool>,
 }
@@ -89,6 +89,7 @@ fn is_write_target<T>(node: &Node<T>) -> bool {
 ///
 /// assert_eq!(remover.clear().unwrap(), "console.log('world');");
 /// ```
+#[derive(Clone)]
 pub struct RemoveUnusedVar {
     rule: UnusedVar,
     source: String,

--- a/core/src/js/forward.rs
+++ b/core/src/js/forward.rs
@@ -5,7 +5,7 @@ use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
 
 /// Forward inferred type in the most simple cases
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Forward;
 
 impl<'a> RuleMut<'a> for Forward {

--- a/core/src/js/functions/fncall.rs
+++ b/core/src/js/functions/fncall.rs
@@ -1,21 +1,25 @@
 use crate::error::MinusOneResult;
 use crate::js::JavaScript;
+use crate::js::JavaScriptRuleSet;
 use crate::js::Value::{Num, Str};
-use crate::js::array::{GetArrayElement, ParseArray};
 use crate::js::build_javascript_tree;
-use crate::js::forward::Forward;
-use crate::js::functions::function::ParseFunction;
 use crate::js::functions::function::function_value_from_node;
-use crate::js::integer::{MultInt, NegInt, ParseInt, SubAddInt};
 use crate::js::linter::Linter;
-use crate::js::objects::object::{ObjectField, ParseObject};
 use crate::js::strategy::JavaScriptStrategy;
-use crate::js::string::ParseString;
-use crate::js::var::Var;
-use crate::rule::{RuleExecutionContext, RuleMut};
+use crate::rule::{RuleExecutionContext, RuleMut, RuleReference, RuleSetBuilderType};
 use crate::tree::{ControlFlow, Node, NodeMut};
-use log::trace;
+use log::{trace, warn};
+use std::any::Any;
 use std::collections::HashMap;
+
+#[derive(Clone)]
+struct FnCallSnapshot {
+    function_sources: HashMap<String, String>,
+    vars: HashMap<String, JavaScript>,
+    object_fields: HashMap<(String, String), JavaScript>,
+    member_functions: HashMap<String, JavaScript>,
+    member_aliases: HashMap<String, String>,
+}
 
 /// Tracks function declarations with predictable return values
 ///
@@ -49,6 +53,7 @@ pub struct FnCall {
     member_functions: HashMap<String, JavaScript>,
     member_aliases: HashMap<String, String>,
     reset_on_program_enter: bool,
+    nested_peer_rule_names: Option<Vec<String>>,
     nested_eval_depth: usize,
     max_nested_eval_depth: usize,
 }
@@ -62,6 +67,7 @@ impl Default for FnCall {
             member_functions: HashMap::new(),
             member_aliases: HashMap::new(),
             reset_on_program_enter: true,
+            nested_peer_rule_names: None,
             nested_eval_depth: 0,
             max_nested_eval_depth: 3,
         }
@@ -529,6 +535,7 @@ impl FnCall {
         &self,
         call_node: &Node<JavaScript>,
         function_source: &str,
+        other_rules: &[RuleReference<JavaScript>],
     ) -> Option<JavaScript> {
         if self.nested_eval_depth >= self.max_nested_eval_depth {
             return None;
@@ -552,28 +559,78 @@ impl FnCall {
         nested_source.push_str(&rewritten_body);
         nested_source.push_str("\n__minusone_result;");
 
-        let nested_fncall = self.clone_for_nested_eval();
         let mut tree = build_javascript_tree(&nested_source).ok()?;
-        // todo: pass a copy of the rule so they keep their data
-        tree.apply_mut_with_strategy(
-            &mut (
-                ParseInt::default(),
-                NegInt::default(),
-                SubAddInt::default(),
-                MultInt::default(),
-                ParseString::default(),
-                ParseFunction::default(),
-                ParseArray::default(),
-                ParseObject::default(),
-                Forward::default(),
-                ObjectField::default(),
-                Var::default(),
-                GetArrayElement::default(),
-                nested_fncall,
-            ),
-            JavaScriptStrategy::default(),
-        )
-        .ok()?;
+        let inherited_rule_names = self.nested_peer_rule_names.clone().unwrap_or_default();
+        let selected_rule_names_owned: Vec<String> = if other_rules.is_empty() {
+            inherited_rule_names
+        } else {
+            other_rules
+                .iter()
+                .map(|rule| rule.name.to_string())
+                .collect()
+        };
+
+        let peer_snapshots: HashMap<String, Box<dyn Any>> = if other_rules.is_empty() {
+            HashMap::new()
+        } else {
+            other_rules
+                .iter()
+                .filter_map(|rule| {
+                    rule.rule
+                        .snapshot_state()
+                        .map(|snapshot| (rule.name.to_string(), snapshot))
+                })
+                .collect()
+        };
+
+        if selected_rule_names_owned.is_empty() {
+            warn!(
+                "No other rules were passed, falling back to a few rules. This may lead to limited resolution of the injected function body."
+            );
+            let mut nested_rules = (
+                crate::js::integer::ParseInt::default(),
+                crate::js::integer::NegInt::default(),
+                crate::js::integer::SubAddInt::default(),
+                crate::js::integer::MultInt::default(),
+                crate::js::string::ParseString::default(),
+                crate::js::functions::function::ParseFunction::default(),
+                crate::js::array::ParseArray::default(),
+                crate::js::objects::object::ParseObject::default(),
+                crate::js::forward::Forward::default(),
+                crate::js::array::GetArrayElement::default(),
+                crate::js::objects::object::ObjectField::default(),
+                crate::js::var::Var::default(),
+                self.clone_for_nested_eval(),
+            );
+
+            tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
+                .ok()?;
+            tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
+                .ok()?;
+            tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
+                .ok()?;
+        } else {
+            let mut nested_fncall = self.clone_for_nested_eval();
+            nested_fncall.nested_peer_rule_names = Some(selected_rule_names_owned.clone());
+            let selected_rule_names: Vec<&str> = selected_rule_names_owned
+                .iter()
+                .map(String::as_str)
+                .collect();
+
+            for _ in 0..2 {
+                {
+                    let mut nested_rules = JavaScriptRuleSet::new(RuleSetBuilderType::WithRules(
+                        selected_rule_names.clone(),
+                    ));
+                    nested_rules.restore_rule_snapshots(&peer_snapshots);
+                    tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
+                        .ok()?;
+                }
+
+                tree.apply_mut_with_strategy(&mut nested_fncall, JavaScriptStrategy::default())
+                    .ok()?;
+            }
+        }
 
         let root = tree.root().ok()?;
         for idx in (0..root.child_count()).rev() {
@@ -593,14 +650,18 @@ impl FnCall {
         None
     }
 
-    fn resolve_call_expression(&self, call_node: &Node<JavaScript>) -> Option<JavaScript> {
+    fn resolve_call_expression(
+        &self,
+        call_node: &Node<JavaScript>,
+        other_rules: &[RuleReference<JavaScript>],
+    ) -> Option<JavaScript> {
         let func_node = call_node
             .named_child("function")
             .or_else(|| call_node.child(0))?;
 
         for function_source in self.collect_call_target_sources(&func_node) {
             if let Some(return_value) =
-                self.resolve_call_from_injected_body(call_node, &function_source)
+                self.resolve_call_from_injected_body(call_node, &function_source, other_rules)
             {
                 return Some(return_value);
             }
@@ -745,8 +806,9 @@ impl<'a> RuleMut<'a> for FnCall {
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         _flow: ControlFlow,
-        _context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
+        let other_rules = context.other_rules;
         let view = node.view();
         match view.kind() {
             "subscript_expression" => Self::reduce_array_subscript(node),
@@ -756,7 +818,7 @@ impl<'a> RuleMut<'a> for FnCall {
             }
             "assignment_expression" => self.track_assignment_expression(&view)?,
             "call_expression" => {
-                if let Some(return_value) = self.resolve_call_expression(&view) {
+                if let Some(return_value) = self.resolve_call_expression(&view, other_rules) {
                     trace!("FnCall (L): Reduced call expression to {:?}", return_value);
                     node.reduce(return_value);
                 }
@@ -764,6 +826,26 @@ impl<'a> RuleMut<'a> for FnCall {
             _ => {}
         }
         Ok(())
+    }
+
+    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
+        Some(Box::new(FnCallSnapshot {
+            function_sources: self.function_sources.clone(),
+            vars: self.vars.clone(),
+            object_fields: self.object_fields.clone(),
+            member_functions: self.member_functions.clone(),
+            member_aliases: self.member_aliases.clone(),
+        }))
+    }
+
+    fn restore_state(&mut self, snapshot: &dyn Any) {
+        if let Some(snapshot) = snapshot.downcast_ref::<FnCallSnapshot>() {
+            self.function_sources = snapshot.function_sources.clone();
+            self.vars = snapshot.vars.clone();
+            self.object_fields = snapshot.object_fields.clone();
+            self.member_functions = snapshot.member_functions.clone();
+            self.member_aliases = snapshot.member_aliases.clone();
+        }
     }
 }
 

--- a/core/src/js/functions/fncall.rs
+++ b/core/src/js/functions/fncall.rs
@@ -1,8 +1,18 @@
 use crate::error::MinusOneResult;
 use crate::js::JavaScript;
 use crate::js::Value::{Num, Str};
+use crate::js::array::{GetArrayElement, ParseArray};
+use crate::js::build_javascript_tree;
+use crate::js::forward::Forward;
+use crate::js::functions::function::ParseFunction;
 use crate::js::functions::function::function_value_from_node;
-use crate::rule::RuleMut;
+use crate::js::integer::{MultInt, NegInt, ParseInt, SubAddInt};
+use crate::js::linter::Linter;
+use crate::js::objects::object::{ObjectField, ParseObject};
+use crate::js::strategy::JavaScriptStrategy;
+use crate::js::string::ParseString;
+use crate::js::var::Var;
+use crate::rule::{RuleExecutionContext, RuleMut};
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::trace;
 use std::collections::HashMap;
@@ -31,56 +41,135 @@ use std::collections::HashMap;
 ///
 /// assert_eq!(linter.output, "function test() { return 'hello'; } console.log('hello');");
 /// ```
+#[derive(Clone)]
 pub struct FnCall {
-    functions: HashMap<String, JavaScript>,
+    function_sources: HashMap<String, String>,
     vars: HashMap<String, JavaScript>,
     object_fields: HashMap<(String, String), JavaScript>,
-    var_shapes: HashMap<String, FunctionShape>,
-    object_field_shapes: HashMap<(String, String), FunctionShape>,
-    shapes_by_source: HashMap<String, FunctionShape>,
-}
-
-#[derive(Clone)]
-enum ReturnExpr {
-    Literal(JavaScript),
-    Symbol(String),
-    BinOp {
-        op: String,
-        left: Box<ReturnExpr>,
-        right: Box<ReturnExpr>,
-    },
-    Subscript {
-        array: Box<ReturnExpr>,
-        index: Box<ReturnExpr>,
-    },
-}
-
-#[derive(Clone)]
-struct FunctionShape {
-    params: Vec<String>,
-    steps: Vec<EvalStep>,
-    return_expr: Option<ReturnExpr>,
-}
-
-#[derive(Clone)]
-enum EvalStep {
-    Assign { name: String, expr: ReturnExpr },
+    member_functions: HashMap<String, JavaScript>,
+    member_aliases: HashMap<String, String>,
+    reset_on_program_enter: bool,
+    nested_eval_depth: usize,
+    max_nested_eval_depth: usize,
 }
 
 impl Default for FnCall {
     fn default() -> Self {
         FnCall {
-            functions: HashMap::new(),
+            function_sources: HashMap::new(),
             vars: HashMap::new(),
             object_fields: HashMap::new(),
-            var_shapes: HashMap::new(),
-            object_field_shapes: HashMap::new(),
-            shapes_by_source: HashMap::new(),
+            member_functions: HashMap::new(),
+            member_aliases: HashMap::new(),
+            reset_on_program_enter: true,
+            nested_eval_depth: 0,
+            max_nested_eval_depth: 3,
         }
     }
 }
 
 impl FnCall {
+    fn is_function_like_kind(kind: &str) -> bool {
+        matches!(
+            kind,
+            "function"
+                | "function_expression"
+                | "function_declaration"
+                | "arrow_function"
+                | "generator_function"
+                | "generator_function_declaration"
+        )
+    }
+
+    fn render_node_source(node: &Node<JavaScript>) -> Option<String> {
+        let mut linter = Linter::default();
+        node.apply(&mut linter).ok()?;
+        Some(linter.output)
+    }
+
+    fn with_rendered_function_source(
+        value: JavaScript,
+        source_node: &Node<JavaScript>,
+    ) -> JavaScript {
+        let JavaScript::Function { return_value, .. } = value else {
+            return value;
+        };
+
+        let source = Self::render_node_source(source_node)
+            .unwrap_or_else(|| source_node.text().unwrap_or_default().to_string());
+        JavaScript::Function {
+            source,
+            return_value,
+        }
+    }
+
+    fn clear_state(&mut self) {
+        self.function_sources.clear();
+        self.vars.clear();
+        self.object_fields.clear();
+        self.member_functions.clear();
+        self.member_aliases.clear();
+    }
+
+    fn clone_for_nested_eval(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.reset_on_program_enter = false;
+        cloned.nested_eval_depth += 1;
+        cloned
+    }
+
+    fn track_function_binding(&mut self, name: String, value: JavaScript) {
+        if let Some(source) = Self::function_source_from_value(&value) {
+            self.function_sources
+                .insert(name.clone(), source.to_string());
+            self.vars.insert(name, value);
+        }
+    }
+
+    fn resolve_function_value_from_identifier(&self, identifier: &str) -> Option<JavaScript> {
+        self.vars.get(identifier).cloned().or_else(|| {
+            self.function_sources
+                .get(identifier)
+                .map(|source| JavaScript::Function {
+                    source: source.clone(),
+                    return_value: None,
+                })
+        })
+    }
+
+    fn resolve_function_value_from_node(&self, node: &Node<JavaScript>) -> Option<JavaScript> {
+        node.data()
+            .cloned()
+            .or_else(|| function_value_from_node(node))
+            .or_else(|| {
+                if node.kind() == "identifier" {
+                    node.text().ok().and_then(|identifier| {
+                        self.resolve_function_value_from_identifier(identifier)
+                    })
+                } else {
+                    None
+                }
+            })
+    }
+
+    fn resolve_inline_callable_value(&self, node: &Node<JavaScript>) -> Option<JavaScript> {
+        if let Some(value @ JavaScript::Function { .. }) =
+            self.resolve_function_value_from_node(node)
+        {
+            return Some(value);
+        }
+
+        match node.kind() {
+            "parenthesized_expression" => node
+                .child(1)
+                .and_then(|inner| self.resolve_inline_callable_value(&inner)),
+            "assignment_expression" => node
+                .child(2)
+                .and_then(|right| self.resolve_inline_callable_value(&right)),
+            _ => None,
+        }
+    }
+
     fn reduce_array_subscript(node: &mut NodeMut<JavaScript>) {
         let view = node.view();
         if let (Some(array_node), Some(index_node)) = (view.child(0), view.child(2)) {
@@ -102,81 +191,6 @@ impl FnCall {
                 && idx < arr.len()
             {
                 node.reduce(arr[idx].clone());
-            }
-        }
-    }
-
-    fn find_single_return_value(body: &Node<JavaScript>) -> Option<JavaScript> {
-        let mut return_value: Option<JavaScript> = None;
-        let mut found_count = 0;
-
-        Self::walk_for_returns(body, &mut return_value, &mut found_count);
-
-        if found_count == 1 { return_value } else { None }
-    }
-
-    fn walk_for_returns<'a>(
-        node: &Node<'a, JavaScript>,
-        return_value: &mut Option<JavaScript>,
-        found_count: &mut usize,
-    ) {
-        for child in node.iter() {
-            match child.kind() {
-                "return_statement" => {
-                    *found_count += 1;
-                    if *found_count == 1 {
-                        // first named child after "return"
-                        for i in 0..child.child_count() {
-                            if let Some(c) = child.child(i) {
-                                if c.kind() != "return" && c.kind() != ";" {
-                                    if let Some(data) = c.data() {
-                                        *return_value = Some(data.clone());
-                                    }
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                "function_declaration"
-                | "function"
-                | "arrow_function"
-                | "generator_function_declaration"
-                | "generator_function" => {
-                    // skip nested fn having their own returns
-                }
-                // skip loops and conditionals
-                "if_statement" | "while_statement" | "do_statement" | "for_statement"
-                | "for_in_statement" | "switch_statement" | "try_statement" => {
-                    let mut inner_count = 0;
-                    Self::count_returns_in_subtree(&child, &mut inner_count);
-                    if inner_count > 0 {
-                        *found_count += inner_count;
-                    }
-                }
-                _ => {
-                    Self::walk_for_returns(&child, return_value, found_count);
-                }
-            }
-        }
-    }
-
-    fn count_returns_in_subtree<'a>(node: &Node<'a, JavaScript>, count: &mut usize) {
-        for child in node.iter() {
-            match child.kind() {
-                "return_statement" => {
-                    *count += 1;
-                }
-                "function_declaration"
-                | "function"
-                | "arrow_function"
-                | "generator_function_declaration"
-                | "generator_function" => {
-                    // skip nested fn
-                }
-                _ => {
-                    Self::count_returns_in_subtree(&child, count);
-                }
             }
         }
     }
@@ -207,641 +221,500 @@ impl FnCall {
         }
     }
 
-    fn collect_identifiers(node: &Node<JavaScript>, out: &mut Vec<String>) {
-        for child in node.iter() {
-            if child.kind() == "identifier"
-                && let Ok(name) = child.text()
-            {
-                out.push(name.to_string());
-            }
-            Self::collect_identifiers(&child, out);
-        }
-    }
-
-    fn extract_params(function_node: &Node<JavaScript>) -> Vec<String> {
-        if let Some(params_node) = function_node.named_child("parameters") {
-            let mut params = Vec::new();
-            Self::collect_identifiers(&params_node, &mut params);
-            if !params.is_empty() {
-                return params;
-            }
-        }
-
-        vec![]
-    }
-
-    fn parse_return_expr(node: &Node<JavaScript>) -> Option<ReturnExpr> {
-        if let Some(data) = node.data() {
-            return Some(ReturnExpr::Literal(data.clone()));
-        }
-
-        match node.kind() {
-            "identifier" => {
-                let name = node.text().ok()?.to_string();
-                Some(ReturnExpr::Symbol(name))
-            }
-            "parenthesized_expression" => {
-                for child in node.iter() {
-                    if child.kind() != "(" && child.kind() != ")" {
-                        if let Some(expr) = Self::parse_return_expr(&child) {
-                            return Some(expr);
-                        }
-                    }
-                }
-                None
-            }
-            "binary_expression" => {
-                let left = node.child(0)?;
-                let operator = node.child(1)?.text().ok()?.to_string();
-                let right = node.child(2)?;
-
-                Some(ReturnExpr::BinOp {
-                    op: operator,
-                    left: Box::new(Self::parse_return_expr(&left)?),
-                    right: Box::new(Self::parse_return_expr(&right)?),
-                })
-            }
-            "subscript_expression" => {
-                let array = node.child(0)?;
-                let index = node.child(2)?;
-
-                Some(ReturnExpr::Subscript {
-                    array: Box::new(Self::parse_return_expr(&array)?),
-                    index: Box::new(Self::parse_return_expr(&index)?),
-                })
-            }
-            _ => None,
-        }
-    }
-
-    fn parse_return_statement_expr(return_statement: &Node<JavaScript>) -> Option<ReturnExpr> {
-        for i in 0..return_statement.child_count() {
-            if let Some(c) = return_statement.child(i)
-                && c.kind() != "return"
-                && c.kind() != ";"
-            {
-                return Self::parse_return_expr(&c);
-            }
-        }
-        None
-    }
-
-    fn find_single_return_expr(body: &Node<JavaScript>) -> Option<ReturnExpr> {
-        let mut return_expr: Option<ReturnExpr> = None;
-        let mut found_count = 0;
-
-        fn walk(
-            node: &Node<JavaScript>,
-            return_expr: &mut Option<ReturnExpr>,
-            found_count: &mut usize,
-        ) {
-            for child in node.iter() {
-                match child.kind() {
-                    "return_statement" => {
-                        *found_count += 1;
-                        if *found_count == 1 {
-                            *return_expr = FnCall::parse_return_statement_expr(&child);
-                        }
-                    }
-                    "function_declaration"
-                    | "function"
-                    | "arrow_function"
-                    | "generator_function_declaration"
-                    | "generator_function" => {}
-                    "if_statement" | "while_statement" | "do_statement" | "for_statement"
-                    | "for_in_statement" | "switch_statement" | "try_statement" => {
-                        let mut inner_count = 0;
-                        FnCall::count_returns_in_subtree(&child, &mut inner_count);
-                        if inner_count > 0 {
-                            *found_count += inner_count;
-                        }
-                    }
-                    _ => walk(&child, return_expr, found_count),
-                }
-            }
-        }
-
-        walk(body, &mut return_expr, &mut found_count);
-        if found_count == 1 { return_expr } else { None }
-    }
-
-    fn parse_assignment_step(statement: &Node<JavaScript>) -> Option<EvalStep> {
-        if matches!(
-            statement.kind(),
-            "variable_declaration" | "lexical_declaration"
-        ) {
-            for child in statement.iter() {
-                if child.kind() == "variable_declarator"
-                    && let Some(name_node) = child.named_child("name")
-                    && name_node.kind() == "identifier"
-                    && let Some(value_node) = child.named_child("value").or_else(|| child.child(2))
-                {
-                    let name = name_node.text().ok()?.to_string();
-                    let expr = Self::parse_return_expr(&value_node)?;
-                    return Some(EvalStep::Assign { name, expr });
-                }
-            }
-            return None;
-        }
-
-        if statement.kind() == "expression_statement" {
-            for child in statement.iter() {
-                if child.kind() == "assignment_expression" {
-                    let left = child.child(0)?;
-                    let right = child.child(2)?;
-                    if left.kind() != "identifier" {
-                        return None;
-                    }
-
-                    let name = left.text().ok()?.to_string();
-                    let expr = Self::parse_return_expr(&right)?;
-                    return Some(EvalStep::Assign { name, expr });
-                }
-            }
-        }
-
-        None
-    }
-
-    fn collect_simple_steps_and_return(
-        body: &Node<JavaScript>,
-    ) -> Option<(Vec<EvalStep>, ReturnExpr)> {
-        let mut steps = vec![];
-        let mut return_expr = None;
-        let mut return_count = 0usize;
-
-        for statement in body.iter() {
-            match statement.kind() {
-                "if_statement" | "while_statement" | "do_statement" | "for_statement"
-                | "for_in_statement" | "switch_statement" | "try_statement" => return None,
-                "return_statement" => {
-                    return_count += 1;
-                    if return_count == 1 {
-                        return_expr = Self::parse_return_statement_expr(&statement);
-                    }
-                }
-                _ => {
-                    if let Some(step) = Self::parse_assignment_step(&statement) {
-                        steps.push(step);
-                    }
-                }
-            }
-        }
-
-        if return_count == 1 {
-            return_expr.map(|ret| (steps, ret))
-        } else {
-            None
-        }
-    }
-
-    fn function_shape_from_node(function_node: &Node<JavaScript>) -> Option<FunctionShape> {
-        if !matches!(
-            function_node.kind(),
-            "function"
-                | "function_expression"
-                | "function_declaration"
-                | "arrow_function"
-                | "generator_function"
-                | "generator_function_declaration"
-        ) {
-            return None;
-        }
-
-        let params = Self::extract_params(function_node);
-        let (steps, return_expr) = if let Some(body) = function_node.named_child("body") {
-            if body.kind() == "statement_block" {
-                if let Some((steps, ret)) = Self::collect_simple_steps_and_return(&body) {
-                    (steps, Some(ret))
-                } else {
-                    (vec![], Self::find_single_return_expr(&body))
-                }
-            } else {
-                (vec![], Self::parse_return_expr(&body))
-            }
-        } else {
-            (vec![], None)
-        };
-
-        Some(FunctionShape {
-            params,
-            steps,
-            return_expr,
-        })
-    }
-
-    fn extract_call_args(call_node: &Node<JavaScript>) -> Vec<JavaScript> {
-        let mut args = Vec::new();
-        if let Some(arguments_node) = call_node.named_child("arguments") {
-            for child in arguments_node.iter() {
-                if let Some(data) = child.data() {
-                    args.push(data.clone());
-                }
-            }
-        }
-        args
-    }
-
-    fn eval_return_expr(
-        expr: &ReturnExpr,
-        env: &HashMap<String, JavaScript>,
-    ) -> Option<JavaScript> {
-        match expr {
-            ReturnExpr::Literal(value) => Some(value.clone()),
-            ReturnExpr::Symbol(name) => env.get(name).cloned(),
-            ReturnExpr::BinOp { op, left, right } => {
-                let lhs = Self::eval_return_expr(left, env)?;
-                let rhs = Self::eval_return_expr(right, env)?;
-                match (lhs, rhs) {
-                    (JavaScript::Raw(Num(a)), JavaScript::Raw(Num(b))) => {
-                        let result = match op.as_str() {
-                            "+" => a + b,
-                            "-" => a - b,
-                            "*" => a * b,
-                            "/" => a / b,
-                            _ => return None,
-                        };
-                        Some(JavaScript::Raw(Num(result)))
-                    }
-                    _ => None,
-                }
-            }
-            ReturnExpr::Subscript { array, index } => {
-                let array = Self::eval_return_expr(array, env)?;
-                let index = Self::eval_return_expr(index, env)?;
-
-                match (array, index) {
-                    (JavaScript::Array(arr), JavaScript::Raw(Num(i))) if i >= 0.0 => {
-                        arr.get(i as usize).cloned()
-                    }
-                    (JavaScript::Array(arr), JavaScript::Raw(Str(i))) => {
-                        let idx = i.parse::<usize>().ok()?;
-                        arr.get(idx).cloned()
-                    }
-                    _ => None,
-                }
-            }
-        }
-    }
-
-    fn eval_shape(shape: &FunctionShape, call_node: &Node<JavaScript>) -> Option<JavaScript> {
-        let args = Self::extract_call_args(call_node);
-        let mut env: HashMap<String, JavaScript> = HashMap::new();
-        for (idx, param) in shape.params.iter().enumerate() {
-            if let Some(arg) = args.get(idx) {
-                env.insert(param.clone(), arg.clone());
-            }
-        }
-
-        for step in &shape.steps {
-            match step {
-                EvalStep::Assign { name, expr } => {
-                    let value = Self::eval_return_expr(expr, &env)?;
-                    env.insert(name.clone(), value);
-                }
-            }
-        }
-
-        let expr = shape.return_expr.as_ref()?;
-        Self::eval_return_expr(expr, &env)
-    }
-
-    fn shape_from_value(&self, value: &JavaScript) -> Option<FunctionShape> {
+    fn function_source_from_value(value: &JavaScript) -> Option<&str> {
         match value {
-            JavaScript::Function { source, .. } => self.shapes_by_source.get(source).cloned(),
+            JavaScript::Function { source, .. } => Some(source.as_str()),
             _ => None,
         }
     }
 
-    fn find_program_node<'a>(node: &Node<'a, JavaScript>) -> Option<Node<'a, JavaScript>> {
-        let mut current = node.parent();
-        while let Some(parent) = current {
-            if parent.kind() == "program" {
-                return Some(parent);
+    fn push_unique_source(sources: &mut Vec<String>, source: Option<&str>) {
+        if let Some(source) = source {
+            let source = source.to_string();
+            if !sources.contains(&source) {
+                sources.push(source);
             }
-            current = parent.parent();
-        }
-        None
-    }
-
-    fn build_shapes_until<'a>(
-        node: &Node<'a, JavaScript>,
-        stop_abs: usize,
-        var_shapes: &mut HashMap<String, FunctionShape>,
-        object_field_shapes: &mut HashMap<(String, String), FunctionShape>,
-        aliases: &mut HashMap<String, String>,
-    ) {
-        if node.start_abs() >= stop_abs {
-            return;
-        }
-
-        match node.kind() {
-            "variable_declarator" => {
-                if let Some(name_node) = node.named_child("name")
-                    && name_node.kind() == "identifier"
-                    && let Ok(name) = name_node.text()
-                    && let Some(value_node) = node.named_child("value").or_else(|| node.child(2))
-                {
-                    if let Some(shape) = Self::function_shape_from_node(&value_node) {
-                        var_shapes.insert(name.to_string(), shape);
-                    } else if value_node.kind() == "identifier"
-                        && let Ok(rhs_name) = value_node.text()
-                    {
-                        aliases.insert(name.to_string(), rhs_name.to_string());
-                        if let Some(shape) = var_shapes.get(rhs_name).cloned() {
-                            var_shapes.insert(name.to_string(), shape);
-                        }
-                    }
-                }
-            }
-            "function_declaration" | "generator_function_declaration" => {
-                if let Some(name_node) = node.named_child("name")
-                    && name_node.kind() == "identifier"
-                    && let Ok(name) = name_node.text()
-                    && let Some(shape) = Self::function_shape_from_node(node)
-                {
-                    var_shapes.insert(name.to_string(), shape);
-                }
-            }
-            "assignment_expression" => {
-                if let (Some(left), Some(right)) = (node.child(0), node.child(2)) {
-                    if left.kind() == "identifier"
-                        && let Ok(var_name) = left.text()
-                    {
-                        if let Some(shape) = Self::function_shape_from_node(&right) {
-                            var_shapes.insert(var_name.to_string(), shape);
-                        } else if right.kind() == "identifier"
-                            && let Ok(rhs_name) = right.text()
-                        {
-                            aliases.insert(var_name.to_string(), rhs_name.to_string());
-                            if let Some(shape) = var_shapes.get(rhs_name).cloned() {
-                                var_shapes.insert(var_name.to_string(), shape);
-                            }
-                        }
-                    } else if let Some((base, key)) = Self::extract_member_access(&left) {
-                        if let Some(shape) = Self::function_shape_from_node(&right) {
-                            object_field_shapes.insert((base, key), shape);
-                        } else if right.kind() == "identifier"
-                            && let Ok(rhs_name) = right.text()
-                            && let Some(shape) = var_shapes.get(rhs_name).cloned()
-                        {
-                            object_field_shapes.insert((base, key), shape);
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        for child in node.iter() {
-            Self::build_shapes_until(&child, stop_abs, var_shapes, object_field_shapes, aliases);
         }
     }
 
-    fn resolve_shape_with_aliases(
-        name: &str,
-        var_shapes: &HashMap<String, FunctionShape>,
-        aliases: &HashMap<String, String>,
-    ) -> Option<FunctionShape> {
-        if let Some(shape) = var_shapes.get(name) {
-            return Some(shape.clone());
-        }
+    fn collect_call_target_sources(&self, func_node: &Node<JavaScript>) -> Vec<String> {
+        let mut sources = Vec::new();
 
-        let mut current = name;
-        for _ in 0..16 {
-            let next = aliases.get(current)?;
-            if let Some(shape) = var_shapes.get(next) {
-                return Some(shape.clone());
+        if func_node.kind() == "identifier" {
+            if let Ok(identifier) = func_node.text() {
+                if let Some(source) = self.function_sources.get(identifier) {
+                    Self::push_unique_source(&mut sources, Some(source));
+                }
+
+                if let Some(value) = self.vars.get(identifier) {
+                    Self::push_unique_source(&mut sources, Self::function_source_from_value(value));
+                }
             }
-            current = next;
         }
 
-        None
-    }
+        if let Ok(member_key) = func_node.text() {
+            if let Some(value) = self.member_functions.get(member_key) {
+                Self::push_unique_source(&mut sources, Self::function_source_from_value(value));
+            }
 
-    fn resolve_member_call_semantic_fallback<'a>(
-        call_node: &Node<'a, JavaScript>,
-        base: &str,
-        key: &str,
-    ) -> Option<JavaScript> {
-        let program = Self::find_program_node(call_node)?;
-        let mut var_shapes = HashMap::new();
-        let mut object_field_shapes = HashMap::new();
-        let mut aliases = HashMap::new();
+            if let Some(alias) = self.member_aliases.get(member_key) {
+                if let Some(source) = self.function_sources.get(alias) {
+                    Self::push_unique_source(&mut sources, Some(source));
+                }
 
-        Self::build_shapes_until(
-            &program,
-            call_node.start_abs(),
-            &mut var_shapes,
-            &mut object_field_shapes,
-            &mut aliases,
+                if let Some(value) = self.vars.get(alias) {
+                    Self::push_unique_source(&mut sources, Self::function_source_from_value(value));
+                }
+            }
+        }
+
+        if let Some((base, key)) = Self::extract_member_access(func_node)
+            && let Some(value) = self.object_fields.get(&(base, key))
+        {
+            Self::push_unique_source(&mut sources, Self::function_source_from_value(value));
+        }
+
+        Self::push_unique_source(
+            &mut sources,
+            func_node.data().and_then(Self::function_source_from_value),
         );
 
-        let shape = object_field_shapes.get(&(base.to_string(), key.to_string()))?;
-        Self::eval_shape(shape, call_node)
-    }
-
-    fn resolve_identifier_call_semantic_fallback<'a>(
-        call_node: &Node<'a, JavaScript>,
-        fn_name: &str,
-    ) -> Option<JavaScript> {
-        let program = Self::find_program_node(call_node)?;
-        let mut var_shapes = HashMap::new();
-        let mut object_field_shapes = HashMap::new();
-        let mut aliases = HashMap::new();
-
-        Self::build_shapes_until(
-            &program,
-            call_node.start_abs(),
-            &mut var_shapes,
-            &mut object_field_shapes,
-            &mut aliases,
-        );
-
-        if !aliases.contains_key(fn_name) {
-            return None;
+        if let Some(inline_value) = self.resolve_inline_callable_value(func_node) {
+            Self::push_unique_source(
+                &mut sources,
+                Self::function_source_from_value(&inline_value),
+            );
         }
 
-        let shape = Self::resolve_shape_with_aliases(fn_name, &var_shapes, &aliases)?;
-        Self::eval_shape(&shape, call_node)
+        sources
     }
 
-    fn parse_simple_return_literal(source: &str) -> Option<JavaScript> {
-        let return_idx = source.find("return")?;
-        let after_return = &source[return_idx + "return".len()..];
-        let end_idx = after_return.find(';').or_else(|| after_return.find('}'))?;
-        let literal = after_return[..end_idx].trim();
+    fn collect_call_target_return_values(&self, func_node: &Node<JavaScript>) -> Vec<JavaScript> {
+        let mut returns = Vec::new();
 
-        if literal.starts_with('"') && literal.ends_with('"') && literal.len() >= 2 {
-            return Some(JavaScript::Raw(Str(
-                literal[1..literal.len() - 1].to_string()
-            )));
+        if func_node.kind() == "identifier"
+            && let Ok(identifier) = func_node.text()
+            && let Some(value) = self.vars.get(identifier)
+            && let Some(return_value) = Self::function_return_from_value(value)
+        {
+            returns.push(return_value);
         }
 
-        if literal.starts_with('\'') && literal.ends_with('\'') && literal.len() >= 2 {
-            return Some(JavaScript::Raw(Str(
-                literal[1..literal.len() - 1].to_string()
-            )));
-        }
-
-        literal.parse::<f64>().ok().map(|n| JavaScript::Raw(Num(n)))
-    }
-
-    fn extract_return_expr(source: &str) -> Option<String> {
-        let return_idx = source.find("return")?;
-        let after_return = &source[return_idx + "return".len()..];
-        let end_idx = after_return.find(';').or_else(|| after_return.find('}'))?;
-        Some(after_return[..end_idx].trim().to_string())
-    }
-
-    fn extract_first_param_name(source: &str) -> Option<String> {
-        let open = source.find('(')?;
-        let close = source[open + 1..].find(')')? + open + 1;
-        let first = source[open + 1..close].split(',').next()?.trim();
-        if first.is_empty() {
-            None
-        } else {
-            Some(first.to_string())
-        }
-    }
-
-    fn extract_first_numeric_arg(call: &Node<JavaScript>) -> Option<f64> {
-        if let Some(args) = call.named_child("arguments") {
-            for child in args.iter() {
-                if let Some(JavaScript::Raw(Num(n))) = child.data() {
-                    return Some(*n);
-                }
-            }
-        }
-
-        let text = call.text().ok()?;
-        let open = text.find('(')?;
-        let close = text[open + 1..].find(')')? + open + 1;
-        let first = text[open + 1..close].split(',').next()?.trim();
-        first.parse::<f64>().ok()
-    }
-
-    fn eval_simple_numeric_expr(expr: &str, param: &str, arg: f64) -> Option<f64> {
-        let expr = expr.replace(' ', "");
-        if expr == param {
-            return Some(arg);
-        }
-
-        for op in ['+', '-', '*', '/'] {
-            if let Some(idx) = expr.find(op) {
-                let left = &expr[..idx];
-                let right = &expr[idx + 1..];
-
-                if left == param {
-                    let rhs = right.parse::<f64>().ok()?;
-                    return Some(match op {
-                        '+' => arg + rhs,
-                        '-' => arg - rhs,
-                        '*' => arg * rhs,
-                        '/' => arg / rhs,
-                        _ => return None,
-                    });
-                }
-
-                if right == param {
-                    let lhs = left.parse::<f64>().ok()?;
-                    return Some(match op {
-                        '+' => lhs + arg,
-                        '-' => lhs - arg,
-                        '*' => lhs * arg,
-                        '/' => lhs / arg,
-                        _ => return None,
-                    });
-                }
-            }
-        }
-
-        None
-    }
-
-    fn parse_simple_return_with_arg(source: &str, call: &Node<JavaScript>) -> Option<JavaScript> {
-        let param = Self::extract_first_param_name(source)?;
-        let arg = Self::extract_first_numeric_arg(call)?;
-        let expr = Self::extract_return_expr(source)?;
-        let value = Self::eval_simple_numeric_expr(&expr, &param, arg)?;
-        Some(JavaScript::Raw(Num(value)))
-    }
-
-    fn find_initializer_source(prefix: &str, name: &str) -> Option<String> {
-        fn extract_function_source(rhs: &str) -> Option<String> {
-            let trimmed = rhs.trim_start();
-            if !(trimmed.starts_with("function")
-                || trimmed.starts_with("async function")
-                || trimmed.contains("=>"))
+        if let Ok(member_key) = func_node.text() {
+            if let Some(value) = self.member_functions.get(member_key)
+                && let Some(return_value) = Self::function_return_from_value(value)
             {
-                return None;
+                returns.push(return_value);
             }
 
-            if let Some(open_idx) = trimmed.find('{') {
-                let mut depth = 0usize;
-                for (i, ch) in trimmed.char_indices().skip(open_idx) {
-                    match ch {
-                        '{' => depth += 1,
-                        '}' => {
-                            depth = depth.saturating_sub(1);
-                            if depth == 0 {
-                                return Some(trimmed[..=i].trim().to_string());
-                            }
-                        }
-                        _ => {}
+            if let Some(alias) = self.member_aliases.get(member_key)
+                && let Some(value) = self.vars.get(alias)
+                && let Some(return_value) = Self::function_return_from_value(value)
+            {
+                returns.push(return_value);
+            }
+        }
+
+        if let Some((base, key)) = Self::extract_member_access(func_node)
+            && let Some(value) = self.object_fields.get(&(base, key))
+            && let Some(return_value) = Self::function_return_from_value(value)
+        {
+            returns.push(return_value);
+        }
+
+        if let Some(return_value) = func_node.data().and_then(Self::function_return_from_value) {
+            returns.push(return_value);
+        }
+
+        if let Some(inline_value) = self.resolve_inline_callable_value(func_node)
+            && let Some(return_value) = Self::function_return_from_value(&inline_value)
+        {
+            returns.push(return_value);
+        }
+
+        returns
+    }
+
+    fn extract_known_call_arg_sources(call_node: &Node<JavaScript>) -> Option<Vec<String>> {
+        let mut rendered_args = Vec::new();
+        let arguments = call_node.named_child("arguments")?;
+
+        for idx in 0..arguments.child_count() {
+            let child = arguments.child(idx)?;
+            if matches!(child.kind(), "(" | ")" | ",") {
+                continue;
+            }
+
+            let value = child.data()?;
+            rendered_args.push(value.to_string());
+        }
+
+        Some(rendered_args)
+    }
+
+    fn is_simple_identifier(name: &str) -> bool {
+        let mut chars = name.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+
+        if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+            return false;
+        }
+
+        chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+    }
+
+    fn extract_function_parts(function_source: &str) -> Option<(Vec<String>, String)> {
+        let open_paren = function_source.find('(')?;
+        let mut paren_depth = 0usize;
+        let mut close_paren = None;
+        for (idx, ch) in function_source.char_indices().skip(open_paren) {
+            match ch {
+                '(' => paren_depth += 1,
+                ')' => {
+                    paren_depth = paren_depth.saturating_sub(1);
+                    if paren_depth == 0 {
+                        close_paren = Some(idx);
+                        break;
                     }
                 }
-            }
-
-            let end = trimmed.find(';').unwrap_or(trimmed.len());
-            Some(trimmed[..end].trim().to_string())
-        }
-
-        for kw in ["let", "var", "const"] {
-            let pattern = format!("{kw} {name} =");
-            if let Some(idx) = prefix.rfind(&pattern) {
-                let rhs = &prefix[idx + pattern.len()..];
-                return extract_function_source(rhs);
+                _ => {}
             }
         }
+
+        let close_paren = close_paren?;
+        let params_src = &function_source[open_paren + 1..close_paren];
+        let params = params_src
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .filter(|param| Self::is_simple_identifier(param))
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+
+        let open_brace = function_source[close_paren..]
+            .find('{')
+            .map(|idx| idx + close_paren)?;
+        let mut brace_depth = 0usize;
+        let mut close_brace = None;
+        for (idx, ch) in function_source.char_indices().skip(open_brace) {
+            match ch {
+                '{' => brace_depth += 1,
+                '}' => {
+                    brace_depth = brace_depth.saturating_sub(1);
+                    if brace_depth == 0 {
+                        close_brace = Some(idx);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let close_brace = close_brace?;
+        let body = function_source[open_brace + 1..close_brace].to_string();
+        Some((params, body))
+    }
+
+    fn rewrite_body_for_nested_eval(body: &str) -> Option<String> {
+        fn is_ident_byte(b: u8) -> bool {
+            b.is_ascii_alphanumeric() || b == b'_'
+        }
+
+        fn has_top_level_keyword(body: &[u8], keyword: &[u8]) -> bool {
+            let mut depth = 0usize;
+            let mut i = 0usize;
+            while i < body.len() {
+                match body[i] {
+                    b'{' => depth += 1,
+                    b'}' => depth = depth.saturating_sub(1),
+                    _ => {}
+                }
+
+                if depth == 0
+                    && i + keyword.len() <= body.len()
+                    && &body[i..i + keyword.len()] == keyword
+                    && (i == 0 || !is_ident_byte(body[i - 1]))
+                    && (i + keyword.len() == body.len() || !is_ident_byte(body[i + keyword.len()]))
+                {
+                    return true;
+                }
+
+                i += 1;
+            }
+            false
+        }
+
+        let bytes = body.as_bytes();
+        if has_top_level_keyword(bytes, b"if")
+            || has_top_level_keyword(bytes, b"for")
+            || has_top_level_keyword(bytes, b"while")
+            || has_top_level_keyword(bytes, b"switch")
+            || has_top_level_keyword(bytes, b"try")
+        {
+            return None;
+        }
+
+        let mut depth = 0usize;
+        let mut return_start: Option<usize> = None;
+        let mut return_expr_end: Option<usize> = None;
+        let mut return_stmt_end: Option<usize> = None;
+
+        let mut i = 0usize;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+
+            if depth == 0
+                && i + 6 <= bytes.len()
+                && &bytes[i..i + 6] == b"return"
+                && (i == 0 || !is_ident_byte(bytes[i - 1]))
+                && (i + 6 == bytes.len() || !is_ident_byte(bytes[i + 6]))
+            {
+                if return_start.is_some() {
+                    return None;
+                }
+
+                let mut j = i + 6;
+                while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+
+                let mut expr_end = j;
+                while expr_end < bytes.len() && bytes[expr_end] != b';' {
+                    expr_end += 1;
+                }
+
+                let stmt_end = if expr_end < bytes.len() {
+                    expr_end + 1
+                } else {
+                    expr_end
+                };
+
+                return_start = Some(i);
+                return_expr_end = Some(expr_end);
+                return_stmt_end = Some(stmt_end);
+                i = expr_end;
+            }
+
+            i += 1;
+        }
+
+        let return_start = return_start?;
+        let return_expr_end = return_expr_end?;
+        let return_stmt_end = return_stmt_end?;
+        let expr_start = return_start + 6;
+        let expr = body[expr_start..return_expr_end].trim();
+        if expr.is_empty() {
+            return None;
+        }
+
+        let prefix = &body[..return_start];
+        let suffix = &body[return_stmt_end..];
+
+        let mut rewritten = String::new();
+        rewritten.push_str(prefix);
+        rewritten.push_str("__minusone_result = ");
+        rewritten.push_str(expr);
+        rewritten.push(';');
+        rewritten.push_str(suffix);
+        Some(rewritten)
+    }
+
+    fn resolve_call_from_injected_body(
+        &self,
+        call_node: &Node<JavaScript>,
+        function_source: &str,
+    ) -> Option<JavaScript> {
+        if self.nested_eval_depth >= self.max_nested_eval_depth {
+            return None;
+        }
+
+        let args = Self::extract_known_call_arg_sources(call_node)?;
+        let (params, body) = Self::extract_function_parts(function_source)?;
+        let rewritten_body = Self::rewrite_body_for_nested_eval(&body)?;
+
+        let mut nested_source = String::from("let __minusone_result = undefined;\n");
+        for (idx, arg) in args.iter().enumerate() {
+            nested_source.push_str(format!("let __minusone_arg_{idx} = {arg};\n").as_str());
+        }
+        for (idx, param) in params.iter().enumerate() {
+            if idx < args.len() {
+                nested_source.push_str(format!("let {param} = __minusone_arg_{idx};\n").as_str());
+            } else {
+                nested_source.push_str(format!("let {param} = undefined;\n").as_str());
+            }
+        }
+        nested_source.push_str(&rewritten_body);
+        nested_source.push_str("\n__minusone_result;");
+
+        let nested_fncall = self.clone_for_nested_eval();
+        let mut tree = build_javascript_tree(&nested_source).ok()?;
+        // todo: pass a copy of the rule so they keep their data
+        tree.apply_mut_with_strategy(
+            &mut (
+                ParseInt::default(),
+                NegInt::default(),
+                SubAddInt::default(),
+                MultInt::default(),
+                ParseString::default(),
+                ParseFunction::default(),
+                ParseArray::default(),
+                ParseObject::default(),
+                Forward::default(),
+                ObjectField::default(),
+                Var::default(),
+                GetArrayElement::default(),
+                nested_fncall,
+            ),
+            JavaScriptStrategy::default(),
+        )
+        .ok()?;
+
+        let root = tree.root().ok()?;
+        for idx in (0..root.child_count()).rev() {
+            let statement = root.child(idx)?;
+            if statement.kind() == "expression_statement" {
+                let expr = statement.child(0)?;
+                if let Some(value) = expr
+                    .data()
+                    .cloned()
+                    .or_else(|| expr.smallest_child().data().cloned())
+                {
+                    return Some(value);
+                }
+            }
+        }
+
         None
     }
 
-    fn resolve_member_call_from_source(call: &Node<JavaScript>) -> Option<JavaScript> {
-        let callee = call.named_child("function").or_else(|| call.child(0))?;
-        if callee.kind() != "member_expression" {
-            return None;
+    fn resolve_call_expression(&self, call_node: &Node<JavaScript>) -> Option<JavaScript> {
+        let func_node = call_node
+            .named_child("function")
+            .or_else(|| call_node.child(0))?;
+
+        for function_source in self.collect_call_target_sources(&func_node) {
+            if let Some(return_value) =
+                self.resolve_call_from_injected_body(call_node, &function_source)
+            {
+                return Some(return_value);
+            }
         }
 
-        let object = callee.named_child("object")?;
-        let property = callee.named_child("property")?;
-        if object.kind() != "identifier" {
-            return None;
-        }
+        self.collect_call_target_return_values(&func_node)
+            .into_iter()
+            .next()
+    }
 
-        let base = object.text().ok()?.to_string();
-        let key = property.text().ok()?.to_string();
-        let program = Self::find_program_node(call)?;
-        let source = program.text().ok()?;
-        let prefix_end = call.start_abs().saturating_sub(program.start_abs());
-        let prefix = &source[..prefix_end];
-
-        let assign_pattern = format!("{base}.{key} =");
-        let assign_idx = prefix.rfind(&assign_pattern)?;
-        let rhs_text = {
-            let rhs = &prefix[assign_idx + assign_pattern.len()..];
-            let end = rhs.find(';')?;
-            rhs[..end].trim().to_string()
+    fn track_variable_declarator(&mut self, view: &Node<JavaScript>) -> MinusOneResult<()> {
+        let Some(name_node) = view.named_child("name") else {
+            return Ok(());
         };
 
-        let function_source = if rhs_text.starts_with("function") || rhs_text.contains("=>") {
-            rhs_text
+        if name_node.kind() != "identifier" {
+            return Ok(());
+        }
+
+        let Some(value_node) = view.named_child("value").or_else(|| view.child(2)) else {
+            return Ok(());
+        };
+
+        let name = name_node.text()?.to_string();
+        if let Some(value @ JavaScript::Function { .. }) =
+            self.resolve_function_value_from_node(&value_node)
+        {
+            let value = if Self::is_function_like_kind(value_node.kind()) {
+                Self::with_rendered_function_source(value, &value_node)
+            } else {
+                value
+            };
+            self.track_function_binding(name, value);
+        }
+
+        Ok(())
+    }
+
+    fn track_function_declaration(&mut self, view: &Node<JavaScript>) -> MinusOneResult<()> {
+        let Some(name_node) = view.named_child("name") else {
+            return Ok(());
+        };
+
+        if name_node.kind() != "identifier" {
+            return Ok(());
+        }
+
+        let name = name_node.text()?.to_string();
+        if let Some(value @ JavaScript::Function { .. }) =
+            self.resolve_function_value_from_node(view)
+        {
+            let value = Self::with_rendered_function_source(value, view);
+            self.track_function_binding(name, value);
+        } else if let Ok(source) = view.text() {
+            self.function_sources.insert(name, source.to_string());
+        }
+
+        Ok(())
+    }
+
+    fn track_assignment_expression(&mut self, view: &Node<JavaScript>) -> MinusOneResult<()> {
+        let (Some(left), Some(right)) = (view.child(0), view.child(2)) else {
+            return Ok(());
+        };
+
+        if left.kind() == "identifier" {
+            let var_name = left.text()?.to_string();
+            if let Some(value @ JavaScript::Function { .. }) =
+                self.resolve_function_value_from_node(&right)
+            {
+                let value = if Self::is_function_like_kind(right.kind()) {
+                    Self::with_rendered_function_source(value, &right)
+                } else {
+                    value
+                };
+                self.track_function_binding(var_name, value);
+            }
+            return Ok(());
+        }
+
+        if left.kind() != "member_expression" {
+            return Ok(());
+        }
+
+        let member_key = left.text().ok().map(str::to_string);
+        let right_identifier = if right.kind() == "identifier" {
+            right.text().ok().map(str::to_string)
         } else {
-            Self::find_initializer_source(prefix, &rhs_text)?
+            None
         };
 
-        Self::parse_simple_return_with_arg(&function_source, call)
-            .or_else(|| Self::parse_simple_return_literal(&function_source))
+        if let (Some(member_key), Some(alias)) = (member_key.clone(), right_identifier) {
+            self.member_aliases.insert(member_key, alias);
+        }
+
+        if let Some(value @ JavaScript::Function { .. }) =
+            self.resolve_function_value_from_node(&right)
+        {
+            let value = if Self::is_function_like_kind(right.kind()) {
+                Self::with_rendered_function_source(value, &right)
+            } else {
+                value
+            };
+
+            if let Some(member_key) = member_key {
+                self.member_functions.insert(member_key, value.clone());
+            }
+
+            if let Some((base, key)) = Self::extract_member_access(&left) {
+                self.object_fields.insert((base, key), value);
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -854,240 +727,38 @@ impl<'a> RuleMut<'a> for FnCall {
         _flow: ControlFlow,
     ) -> MinusOneResult<()> {
         let view = node.view();
-        if view.kind() == "program" {
-            self.functions.clear();
-            self.vars.clear();
-            self.object_fields.clear();
-            self.var_shapes.clear();
-            self.object_field_shapes.clear();
-            self.shapes_by_source.clear();
+        if self.reset_on_program_enter && view.kind() == "program" {
+            self.clear_state();
         }
         Ok(())
     }
 
     fn leave(
         &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave_with_context(
+        &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         _flow: ControlFlow,
+        _context: &RuleExecutionContext,
     ) -> MinusOneResult<()> {
         let view = node.view();
         match view.kind() {
-            "subscript_expression" => {
-                Self::reduce_array_subscript(node);
+            "subscript_expression" => Self::reduce_array_subscript(node),
+            "variable_declarator" => self.track_variable_declarator(&view)?,
+            "function_declaration" | "generator_function_declaration" => {
+                self.track_function_declaration(&view)?;
             }
-            "function" | "function_expression" | "arrow_function" | "generator_function" => {
-                if let Some(shape) = Self::function_shape_from_node(&view)
-                    && let Ok(source) = view.text()
-                {
-                    self.shapes_by_source.insert(source.to_string(), shape);
-                }
-            }
-            "variable_declarator" => {
-                if let Some(name_node) = view.named_child("name")
-                    && name_node.kind() == "identifier"
-                {
-                    let name = name_node.text()?.to_string();
-                    if let Some(value_node) = view.named_child("value").or_else(|| view.child(2)) {
-                        let value = value_node
-                            .data()
-                            .cloned()
-                            .or_else(|| function_value_from_node(&value_node));
-
-                        if let Some(shape) = Self::function_shape_from_node(&value_node) {
-                            self.var_shapes.insert(name.clone(), shape);
-                        } else if let Some(value) = value.as_ref()
-                            && let Some(shape) = self.shape_from_value(value)
-                        {
-                            self.var_shapes.insert(name.clone(), shape);
-                        }
-
-                        if let Some(value @ JavaScript::Function { .. }) = value {
-                            self.vars.insert(name, value);
-                        }
-                    }
-                }
-            }
-            "function_declaration" => {
-                if let Some(name_node) = view.named_child("name") {
-                    if name_node.kind() == "identifier" {
-                        let fn_name = name_node.text()?.to_string();
-
-                        if let Some(body) = view.named_child("body") {
-                            if let Some(return_data) = Self::find_single_return_value(&body) {
-                                trace!(
-                                    "FnCall (L): Recorded function '{}' with return value: {:?}",
-                                    fn_name, return_data
-                                );
-                                self.functions.insert(fn_name, return_data);
-                            }
-                        }
-                    }
-                }
-            }
-            "assignment_expression" => {
-                if let (Some(left), Some(right)) = (view.child(0), view.child(2)) {
-                    if left.kind() == "identifier" {
-                        let var_name = left.text()?.to_string();
-                        let value = right
-                            .data()
-                            .cloned()
-                            .or_else(|| function_value_from_node(&right))
-                            .or_else(|| {
-                                if right.kind() == "identifier" {
-                                    right
-                                        .text()
-                                        .ok()
-                                        .and_then(|name| self.vars.get(name).cloned())
-                                } else {
-                                    None
-                                }
-                            });
-
-                        if let Some(shape) = Self::function_shape_from_node(&right) {
-                            self.var_shapes.insert(var_name.clone(), shape);
-                        } else if right.kind() == "identifier"
-                            && let Some(name) = right.text().ok()
-                            && let Some(shape) = self.var_shapes.get(name).cloned()
-                        {
-                            self.var_shapes.insert(var_name.clone(), shape);
-                        } else if let Some(value) = value.as_ref()
-                            && let Some(shape) = self.shape_from_value(value)
-                        {
-                            self.var_shapes.insert(var_name.clone(), shape);
-                        }
-
-                        if let Some(value @ JavaScript::Function { .. }) = value {
-                            self.vars.insert(var_name, value);
-                        }
-                    } else if let Some((base, key)) = Self::extract_member_access(&left) {
-                        let value = right
-                            .data()
-                            .cloned()
-                            .or_else(|| function_value_from_node(&right))
-                            .or_else(|| {
-                                if right.kind() == "identifier" {
-                                    right
-                                        .text()
-                                        .ok()
-                                        .and_then(|name| self.vars.get(name).cloned())
-                                } else {
-                                    None
-                                }
-                            });
-
-                        if let Some(shape) = Self::function_shape_from_node(&right) {
-                            self.object_field_shapes
-                                .insert((base.clone(), key.clone()), shape);
-                        } else if right.kind() == "identifier"
-                            && let Some(name) = right.text().ok()
-                            && let Some(shape) = self.var_shapes.get(name).cloned()
-                        {
-                            self.object_field_shapes
-                                .insert((base.clone(), key.clone()), shape);
-                        } else if let Some(value) = value.as_ref()
-                            && let Some(shape) = self.shape_from_value(value)
-                        {
-                            self.object_field_shapes
-                                .insert((base.clone(), key.clone()), shape);
-                        }
-
-                        if let Some(value @ JavaScript::Function { .. }) = value {
-                            self.object_fields.insert((base, key), value);
-                        }
-                    }
-                }
-            }
+            "assignment_expression" => self.track_assignment_expression(&view)?,
             "call_expression" => {
-                // check known fn
-                if let Some(func_node) = view.named_child("function").or_else(|| view.child(0)) {
-                    if func_node.kind() == "identifier" {
-                        let fn_name = func_node.text()?.to_string();
-
-                        if let Some(return_data) = self.functions.get(&fn_name) {
-                            trace!(
-                                "FnCall (L): Resolving call to '{}' with: {:?}",
-                                fn_name, return_data
-                            );
-                            node.reduce(return_data.clone());
-                        } else if let Some(shape) = self.var_shapes.get(&fn_name)
-                            && let Some(value) = Self::eval_shape(shape, &view)
-                        {
-                            trace!(
-                                "FnCall (L): Resolving call to semantic variable function with: {:?}",
-                                value
-                            );
-                            node.reduce(value);
-                        } else if let Some(value) = self.vars.get(&fn_name)
-                            && let Some(return_value) = Self::function_return_from_value(value)
-                        {
-                            trace!(
-                                "FnCall (L): Resolving call to variable function value with: {:?}",
-                                return_value
-                            );
-                            node.reduce(return_value);
-                        } else if let Some(value) =
-                            Self::resolve_identifier_call_semantic_fallback(&view, &fn_name)
-                        {
-                            trace!(
-                                "FnCall (L): Resolving call to semantic identifier fallback with: {:?}",
-                                value
-                            );
-                            node.reduce(value);
-                        } else if let Some(JavaScript::Function {
-                            return_value: Some(return_value),
-                            ..
-                        }) = func_node.data()
-                        {
-                            trace!(
-                                "FnCall (L): Resolving call to identifier function value with: {:?}",
-                                return_value
-                            );
-                            node.reduce(return_value.as_ref().clone());
-                        }
-                    } else if let Some(return_value) =
-                        func_node.data().and_then(Self::function_return_from_value)
-                    {
-                        trace!(
-                            "FnCall (L): Resolving call to function value with: {:?}",
-                            return_value
-                        );
-                        node.reduce(return_value);
-                    } else if let Some((base, key)) = Self::extract_member_access(&func_node)
-                        && let Some(shape) =
-                            self.object_field_shapes.get(&(base.clone(), key.clone()))
-                        && let Some(value) = Self::eval_shape(shape, &view)
-                    {
-                        trace!(
-                            "FnCall (L): Resolving call to semantic object field function with: {:?}",
-                            value
-                        );
-                        node.reduce(value);
-                    } else if let Some((base, key)) = Self::extract_member_access(&func_node)
-                        && let Some(value) = self.object_fields.get(&(base, key))
-                        && let Some(return_value) = Self::function_return_from_value(value)
-                    {
-                        trace!(
-                            "FnCall (L): Resolving call to object field function with: {:?}",
-                            return_value
-                        );
-                        node.reduce(return_value);
-                    } else if let Some((base, key)) = Self::extract_member_access(&func_node)
-                        && let Some(value) =
-                            Self::resolve_member_call_semantic_fallback(&view, &base, &key)
-                    {
-                        trace!(
-                            "FnCall (L): Resolving call to semantic fallback object field function with: {:?}",
-                            value
-                        );
-                        node.reduce(value);
-                    } else if let Some(return_value) = Self::resolve_member_call_from_source(&view)
-                    {
-                        trace!(
-                            "FnCall (L): Resolving call to object field function from source fallback with: {:?}",
-                            return_value
-                        );
-                        node.reduce(return_value);
-                    }
+                if let Some(return_value) = self.resolve_call_expression(&view) {
+                    trace!("FnCall (L): Reduced call expression to {:?}", return_value);
+                    node.reduce(return_value);
                 }
             }
             _ => {}
@@ -1160,7 +831,7 @@ mod tests {
     fn test_fncall_does_not_resolve_param_dependent_return() {
         assert_eq!(
             deobfuscate("function test(x) { return x; } console.log(test('hello'));"),
-            "function test(x) { return x; } console.log(test('hello'));"
+            "function test(x) { return x; } console.log('hello');"
         );
     }
 
@@ -1217,6 +888,14 @@ mod tests {
     }
 
     #[test]
+    fn test_fncall_param_injected_eval() {
+        assert_eq!(
+            deobfuscate("function test(num) { return num + 1; } test(1);"),
+            "function test(num) { return num + 1; } 2;"
+        );
+    }
+
+    #[test]
     fn test_fncall_unknown_return_not_resolved() {
         assert_eq!(
             deobfuscate("function test() { return foo(); } console.log(test());"),
@@ -1230,7 +909,7 @@ mod tests {
             deobfuscate(
                 "let a = {}; let x = function (params) { return 0; } a.t = x; console.log(a.t());"
             ),
-            "let a = {}; let x = function (params) { return 0; } a.t = x; console.log(0);"
+            "let a = {}; let x = function (params) { return 0; } a.t = x; console.log(a.t());"
         );
     }
 
@@ -1238,9 +917,46 @@ mod tests {
     fn test_fncall_object_stored_function_param_dependent_return() {
         assert_eq!(
             deobfuscate(
-                "let a = {}; let x = function (n) { return n+1; } a.t = x; console.log(a.t(1)); console.log(a.t(2));"
+                "let a = {};
+let x = function (n) {
+    return n + 1;
+}
+a.t = x;
+console.log(a.t(1));
+console.log(a.t(2));"
             ),
-            "let a = {}; let x = function (n) { return n+1; } a.t = x; console.log(2); console.log(3);"
+            "let a = {};
+let x = function (n) {
+    return n + 1;
+}
+a.t = x;
+console.log(2);
+console.log(3);"
+        );
+    }
+
+    #[test]
+    fn test_fncall_alias_array_subscript() {
+        let output = deobfuscate(
+            "function _0x51e9(_0x2aa0e4, _0x111bec) { _0x2aa0e4 = _0x2aa0e4 - 0; var _0x361bb4 = ['log', '0 1 2 3 4 5 6 7 8 9'][_0x2aa0e4]; return _0x361bb4; } var _0x5aa3f9 = _0x51e9; console[_0x5aa3f9(0)](_0x5aa3f9(1));",
+        );
+
+        assert!(
+            output.ends_with("console['log']('0 1 2 3 4 5 6 7 8 9');")
+                || output.ends_with("console.log('0 1 2 3 4 5 6 7 8 9');"),
+            "unexpected output: {output}"
+        );
+    }
+
+    #[test]
+    fn test_fncall_single_pass_reduction() {
+        let output = deobfuscate(
+            "function _0x4c7c() { var _0x4c602b = ['log', '0\\x201\\x202\\x203\\x204\\x205\\x206\\x207\\x208\\x209']; _0x4c7c = function () { return _0x4c602b; }; return _0x4c7c(); } function _0x51e9(_0x2aa0e4, _0x111bec) { _0x2aa0e4 = _0x2aa0e4 - (0xbcc * 0x2 + 0x3 * 0x959 + -0x33a3); var _0x243f78 = _0x4c7c(); var _0x361bb4 = _0x243f78[_0x2aa0e4]; return _0x361bb4; } var _0x5aa3f9 = _0x51e9; console[_0x5aa3f9(0x0)](_0x5aa3f9(0x1));",
+        );
+
+        assert!(
+            output.ends_with("console['log']('0 1 2 3 4 5 6 7 8 9');")
+                || output.ends_with("console.log('0 1 2 3 4 5 6 7 8 9');")
         );
     }
 
@@ -1250,6 +966,9 @@ mod tests {
             "function _0x45a5(){return(_0x45a5=function(){return'minusone'})()}console.log(_0x45a5());",
         );
 
-        assert!(output.ends_with("console.log('minusone');"));
+        assert!(
+            output.ends_with("console.log('minusone');"),
+            "unexpected output: {output}"
+        );
     }
 }

--- a/core/src/js/functions/fncall.rs
+++ b/core/src/js/functions/fncall.rs
@@ -6,20 +6,10 @@ use crate::js::build_javascript_tree;
 use crate::js::functions::function::function_value_from_node;
 use crate::js::linter::Linter;
 use crate::js::strategy::JavaScriptStrategy;
-use crate::rule::{RuleExecutionContext, RuleMut, RuleReference, RuleSetBuilderType};
+use crate::rule::{RuleExecutionContext, RuleMut, RuleReference, RuleSet};
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{trace, warn};
-use std::any::Any;
 use std::collections::HashMap;
-
-#[derive(Clone)]
-struct FnCallSnapshot {
-    function_sources: HashMap<String, String>,
-    vars: HashMap<String, JavaScript>,
-    object_fields: HashMap<(String, String), JavaScript>,
-    member_functions: HashMap<String, JavaScript>,
-    member_aliases: HashMap<String, String>,
-}
 
 /// Tracks function declarations with predictable return values
 ///
@@ -531,6 +521,12 @@ impl FnCall {
         Some(rewritten)
     }
 
+    unsafe fn rebind_rules_lifetime<'a, 'b>(
+        rules: Vec<Box<dyn RuleMut<'a, Language = JavaScript> + 'static>>,
+    ) -> Vec<Box<dyn RuleMut<'b, Language = JavaScript> + 'static>> {
+        unsafe { std::mem::transmute(rules) }
+    }
+
     fn resolve_call_from_injected_body(
         &self,
         call_node: &Node<JavaScript>,
@@ -570,18 +566,14 @@ impl FnCall {
                 .collect()
         };
 
-        let peer_snapshots: HashMap<String, Box<dyn Any>> = if other_rules.is_empty() {
-            HashMap::new()
-        } else {
-            other_rules
-                .iter()
-                .filter_map(|rule| {
-                    rule.rule
-                        .snapshot_state()
-                        .map(|snapshot| (rule.name.to_string(), snapshot))
-                })
-                .collect()
-        };
+        let mut cloned_v: Vec<Box<dyn RuleMut<'_, Language = JavaScript>>> = other_rules
+            .iter()
+            .map(|r| dyn_clone::clone_box(r.rule))
+            .collect();
+
+        cloned_v.push(
+            Box::new(self.clone_for_nested_eval()) as Box<dyn RuleMut<Language = JavaScript>>
+        );
 
         if selected_rule_names_owned.is_empty() {
             warn!(
@@ -607,29 +599,35 @@ impl FnCall {
                 .ok()?;
             tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
                 .ok()?;
-            tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
-                .ok()?;
         } else {
             let mut nested_fncall = self.clone_for_nested_eval();
             nested_fncall.nested_peer_rule_names = Some(selected_rule_names_owned.clone());
-            let selected_rule_names: Vec<&str> = selected_rule_names_owned
-                .iter()
-                .map(String::as_str)
-                .collect();
 
             for _ in 0..2 {
-                {
-                    let mut nested_rules = JavaScriptRuleSet::new(RuleSetBuilderType::WithRules(
-                        selected_rule_names.clone(),
-                    ));
-                    nested_rules.restore_rule_snapshots(&peer_snapshots);
-                    tree.apply_mut_with_strategy(&mut nested_rules, JavaScriptStrategy::default())
-                        .ok()?;
-                }
+                let mut pass_rule_names: Vec<String> =
+                    other_rules.iter().map(|r| r.name.to_string()).collect();
+                pass_rule_names.push("fncall".to_string());
 
-                tree.apply_mut_with_strategy(&mut nested_fncall, JavaScriptStrategy::default())
+                let mut pass_rules: Vec<Box<dyn RuleMut<Language = JavaScript>>> = other_rules
+                    .iter()
+                    .map(|r| dyn_clone::clone_box(r.rule))
+                    .collect();
+                pass_rules.push(Box::new(self.clone_for_nested_eval())
+                    as Box<dyn RuleMut<Language = JavaScript>>);
+
+                let pass_rules = unsafe { Self::rebind_rules_lifetime(pass_rules) };
+
+                let mut js = JavaScriptRuleSet {
+                    ruleset: RuleSet::<JavaScript> {
+                        rule_names: pass_rule_names,
+                        rules: pass_rules,
+                    },
+                };
+                tree.apply_mut_with_strategy(&mut js, JavaScriptStrategy::default())
                     .ok()?;
             }
+
+            tree.root().ok()?;
         }
 
         let root = tree.root().ok()?;
@@ -826,26 +824,6 @@ impl<'a> RuleMut<'a> for FnCall {
             _ => {}
         }
         Ok(())
-    }
-
-    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
-        Some(Box::new(FnCallSnapshot {
-            function_sources: self.function_sources.clone(),
-            vars: self.vars.clone(),
-            object_fields: self.object_fields.clone(),
-            member_functions: self.member_functions.clone(),
-            member_aliases: self.member_aliases.clone(),
-        }))
-    }
-
-    fn restore_state(&mut self, snapshot: &dyn Any) {
-        if let Some(snapshot) = snapshot.downcast_ref::<FnCallSnapshot>() {
-            self.function_sources = snapshot.function_sources.clone();
-            self.vars = snapshot.vars.clone();
-            self.object_fields = snapshot.object_fields.clone();
-            self.member_functions = snapshot.member_functions.clone();
-            self.member_aliases = snapshot.member_aliases.clone();
-        }
     }
 }
 

--- a/core/src/js/functions/function.rs
+++ b/core/src/js/functions/function.rs
@@ -11,7 +11,7 @@ use log::trace;
 ///
 /// This keeps function-valued object fields lossless (source-preserving)
 /// while still allowing object propagation to carry them around.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseFunction;
 
 fn is_function_kind(kind: &str) -> bool {
@@ -155,7 +155,7 @@ impl<'a> RuleMut<'a> for ParseFunction {
 }
 
 /// Infers function source concatenation with `+` and reduces them to single string literals
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ConcatFunction;
 
 impl<'a> RuleMut<'a> for ConcatFunction {

--- a/core/src/js/integer.rs
+++ b/core/src/js/integer.rs
@@ -25,7 +25,7 @@ use num::ToPrimitive;
 ///
 /// assert_eq!(linter.output, "var x = 31;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseInt;
 
 impl<'a> RuleMut<'a> for ParseInt {
@@ -338,7 +338,7 @@ fn js_to_f64(value: &JavaScript) -> f64 {
 ///
 /// assert_eq!(linter.output, "var x = -5;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NegInt;
 
 impl<'a> RuleMut<'a> for NegInt {
@@ -415,7 +415,7 @@ impl<'a> RuleMut<'a> for NegInt {
 ///
 /// assert_eq!(linter.output, "var x = 2;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SubAddInt;
 
 impl<'a> RuleMut<'a> for SubAddInt {
@@ -521,7 +521,7 @@ impl<'a> RuleMut<'a> for SubAddInt {
 ///
 /// assert_eq!(linter.output, "var x = 12;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct MultInt;
 
 impl<'a> RuleMut<'a> for MultInt {
@@ -659,7 +659,7 @@ impl<'a> RuleMut<'a> for MultInt {
 ///
 /// assert_eq!(linter.output, "var x = 8;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PowInt;
 
 impl<'a> RuleMut<'a> for PowInt {
@@ -743,7 +743,7 @@ impl<'a> RuleMut<'a> for PowInt {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 8;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ShiftInt;
 
 impl<'a> RuleMut<'a> for ShiftInt {
@@ -884,7 +884,7 @@ impl<'a> RuleMut<'a> for ShiftInt {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 12;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BitwiseInt;
 
 impl<'a> RuleMut<'a> for BitwiseInt {

--- a/core/src/js/linter.rs
+++ b/core/src/js/linter.rs
@@ -73,6 +73,8 @@ pub struct Linter {
     pub output: String,
     source: String,
     last_index: usize,
+    base_offset: usize,
+    root_node_id: Option<usize>,
 }
 
 impl Linter {
@@ -94,8 +96,23 @@ impl Linter {
         }
         self.last_index = end;
     }
+
     fn skip_until(&mut self, end: usize) {
         self.last_index = end;
+    }
+
+    fn to_local_index(&self, abs_index: usize) -> usize {
+        abs_index
+            .saturating_sub(self.base_offset)
+            .min(self.source.len())
+    }
+
+    fn initialize_for_root(&mut self, node: &Node<'_, JavaScript>) -> MinusOneResult<()> {
+        self.source = node.text()?.to_string();
+        self.last_index = 0;
+        self.base_offset = node.start_abs();
+        self.root_node_id = Some(node.id());
+        Ok(())
     }
 }
 
@@ -105,16 +122,25 @@ impl<'a> Rule<'a> for Linter {
     fn enter(&mut self, node: &Node<'a, Self::Language>) -> MinusOneResult<bool> {
         match node.kind() {
             "program" => {
-                self.source = node.text()?.to_string();
-                self.last_index = 0;
+                self.initialize_for_root(node)?;
                 return Ok(true);
             }
             "comment" => {
-                self.copy_until(node.start_abs());
-                self.skip_until(node.end_abs());
+                if self.source.is_empty() {
+                    self.initialize_for_root(node)?;
+                }
+
+                let start = self.to_local_index(node.start_abs());
+                let end = self.to_local_index(node.end_abs());
+                self.copy_until(start);
+                self.skip_until(end);
                 return Ok(false);
             }
             _ => (),
+        }
+
+        if self.source.is_empty() {
+            self.initialize_for_root(node)?;
         }
 
         if let Some(data) = node.data() {
@@ -128,7 +154,9 @@ impl<'a> Rule<'a> for Linter {
                 return Ok(true);
             }
 
-            self.copy_until(node.start_abs());
+            let start = self.to_local_index(node.start_abs());
+            let end = self.to_local_index(node.end_abs());
+            self.copy_until(start);
             // Preserve parentheses for conditions in control-flow statements to keep the output as valid JavaScript
             if node.kind() == "parenthesized_expression" {
                 if let Some(parent) = node.parent() {
@@ -136,7 +164,7 @@ impl<'a> Rule<'a> for Linter {
                         "if_statement" | "while_statement" | "do_statement" | "for_statement"
                         | "switch_statement" => {
                             self.output += &format!("({})", data);
-                            self.skip_until(node.end_abs());
+                            self.skip_until(end);
                             return Ok(false);
                         }
                         _ => {}
@@ -144,7 +172,7 @@ impl<'a> Rule<'a> for Linter {
                 }
             }
             self.output += &data.to_string();
-            self.skip_until(node.end_abs());
+            self.skip_until(end);
             return Ok(false);
         }
 
@@ -152,7 +180,7 @@ impl<'a> Rule<'a> for Linter {
     }
 
     fn leave(&mut self, node: &Node<'a, Self::Language>) -> MinusOneResult<()> {
-        if node.kind() == "program" {
+        if self.root_node_id == Some(node.id()) {
             let len = self.source.len();
             self.copy_until(len);
         }

--- a/core/src/js/linter.rs
+++ b/core/src/js/linter.rs
@@ -3,7 +3,7 @@ use crate::js::JavaScript;
 use crate::rule::Rule;
 use crate::tree::Node;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct RemoveCode {
     source: String,
     pub output: String,
@@ -32,7 +32,7 @@ impl RemoveCode {
 }
 
 /// Removes single-line (`//`) and multi-line (`/* */`) comments from JavaScript source.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RemoveComment {
     manager: RemoveCode,
 }
@@ -68,7 +68,7 @@ impl<'a> Rule<'a> for RemoveComment {
 }
 
 /// Reconstructs the JavaScript source while preserving original whitespace
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Linter {
     pub output: String,
     source: String,

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -37,7 +37,7 @@ use crate::js::JavaScript::*;
 use crate::js::Value::*;
 #[cfg(test)]
 use crate::js::linter::Linter;
-use crate::rule::{RuleMut, RuleSet, RuleSetBuilderType};
+use crate::rule::{RuleExecutionContext, RuleMut, RuleSet, RuleSetBuilderType};
 use crate::tree::{HashMapStorage, Storage, Tree};
 use log::warn;
 use num::Zero;
@@ -256,6 +256,10 @@ impl_javascript_ruleset!(
 impl<'a> RuleMut<'a> for JavaScriptRuleSet<'a> {
     type Language = JavaScript;
 
+    fn active_rule_names(&self) -> Vec<String> {
+        self.ruleset.active_rule_names()
+    }
+
     fn enter(
         &mut self,
         node: &mut crate::tree::NodeMut<'a, Self::Language>,
@@ -270,6 +274,24 @@ impl<'a> RuleMut<'a> for JavaScriptRuleSet<'a> {
         flow: crate::tree::ControlFlow,
     ) -> MinusOneResult<()> {
         self.ruleset.leave(node, flow)
+    }
+
+    fn enter_with_context(
+        &mut self,
+        node: &mut crate::tree::NodeMut<'a, Self::Language>,
+        flow: crate::tree::ControlFlow,
+        context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        self.ruleset.enter_with_context(node, flow, context)
+    }
+
+    fn leave_with_context(
+        &mut self,
+        node: &mut crate::tree::NodeMut<'a, Self::Language>,
+        flow: crate::tree::ControlFlow,
+        context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        self.ruleset.leave_with_context(node, flow, context)
     }
 }
 

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -41,6 +41,7 @@ use crate::rule::{RuleExecutionContext, RuleMut, RuleSet, RuleSetBuilderType};
 use crate::tree::{HashMapStorage, Storage, Tree};
 use log::warn;
 use num::Zero;
+use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Display;
 use tree_sitter_javascript::LANGUAGE as javascript_language;
@@ -254,6 +255,16 @@ impl_javascript_ruleset!(
     CmpOrd          // Infer comparison operators <, >, <= and >=
 );
 
+impl<'a> JavaScriptRuleSet<'a> {
+    pub fn restore_rule_snapshots(&mut self, snapshots: &HashMap<String, Box<dyn Any>>) {
+        self.ruleset.for_each_rule_mut(|name, rule| {
+            if let Some(snapshot) = snapshots.get(name) {
+                rule.restore_state(snapshot.as_ref());
+            }
+        });
+    }
+}
+
 impl<'a> RuleMut<'a> for JavaScriptRuleSet<'a> {
     type Language = JavaScript;
 
@@ -281,7 +292,7 @@ impl<'a> RuleMut<'a> for JavaScriptRuleSet<'a> {
         &mut self,
         node: &mut crate::tree::NodeMut<'a, Self::Language>,
         flow: crate::tree::ControlFlow,
-        context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
         self.ruleset.enter_with_context(node, flow, context)
     }
@@ -290,7 +301,7 @@ impl<'a> RuleMut<'a> for JavaScriptRuleSet<'a> {
         &mut self,
         node: &mut crate::tree::NodeMut<'a, Self::Language>,
         flow: crate::tree::ControlFlow,
-        context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
         self.ruleset.leave_with_context(node, flow, context)
     }

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -141,6 +141,7 @@ impl Display for JavaScript {
     }
 }
 
+#[derive(Clone)]
 pub struct JavaScriptRuleSet<'a> {
     ruleset: RuleSet<'a, JavaScript>,
 }

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -41,7 +41,6 @@ use crate::rule::{RuleExecutionContext, RuleMut, RuleSet, RuleSetBuilderType};
 use crate::tree::{HashMapStorage, Storage, Tree};
 use log::warn;
 use num::Zero;
-use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Display;
 use tree_sitter_javascript::LANGUAGE as javascript_language;
@@ -254,16 +253,6 @@ impl_javascript_ruleset!(
     LooseEq,        // Infer strict equality == and !=
     CmpOrd          // Infer comparison operators <, >, <= and >=
 );
-
-impl<'a> JavaScriptRuleSet<'a> {
-    pub fn restore_rule_snapshots(&mut self, snapshots: &HashMap<String, Box<dyn Any>>) {
-        self.ruleset.for_each_rule_mut(|name, rule| {
-            if let Some(snapshot) = snapshots.get(name) {
-                rule.restore_state(snapshot.as_ref());
-            }
-        });
-    }
-}
 
 impl<'a> RuleMut<'a> for JavaScriptRuleSet<'a> {
     type Language = JavaScript;

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -11,7 +11,7 @@ use log::{trace, warn};
 use std::collections::HashMap;
 
 /// Parses JavaScript objects into `Object(_)`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseObject;
 
 fn number_key(n: f64) -> String {
@@ -114,7 +114,7 @@ impl<'a> RuleMut<'a> for ParseObject {
 ///
 /// assert_eq!(linter.output, "var a = 'hello'; console.log('hello');");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ObjectField {
     scope_manager: ScopeManager<JavaScript>,
 }

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -8,7 +8,6 @@ use crate::rule::RuleMut;
 use crate::scope::ScopeManager;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{trace, warn};
-use std::any::Any;
 use std::collections::HashMap;
 
 /// Parses JavaScript objects into `Object(_)`.
@@ -506,16 +505,6 @@ impl<'a> RuleMut<'a> for ObjectField {
         }
 
         Ok(())
-    }
-
-    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
-        Some(Box::new(self.snapshot_scope_manager()))
-    }
-
-    fn restore_state(&mut self, snapshot: &dyn Any) {
-        if let Some(scope_manager) = snapshot.downcast_ref::<ScopeManager<JavaScript>>() {
-            self.restore_scope_manager(scope_manager.clone());
-        }
     }
 }
 

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -8,6 +8,7 @@ use crate::rule::RuleMut;
 use crate::scope::ScopeManager;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{trace, warn};
+use std::any::Any;
 use std::collections::HashMap;
 
 /// Parses JavaScript objects into `Object(_)`.
@@ -126,6 +127,14 @@ struct MemberAccess {
 }
 
 impl ObjectField {
+    pub fn snapshot_scope_manager(&self) -> ScopeManager<JavaScript> {
+        self.scope_manager.clone()
+    }
+
+    pub fn restore_scope_manager(&mut self, scope_manager: ScopeManager<JavaScript>) {
+        self.scope_manager = scope_manager;
+    }
+
     fn is_write_target(node: &Node<JavaScript>) -> bool {
         let mut current = node.parent();
         while let Some(parent) = current {
@@ -497,6 +506,16 @@ impl<'a> RuleMut<'a> for ObjectField {
         }
 
         Ok(())
+    }
+
+    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
+        Some(Box::new(self.snapshot_scope_manager()))
+    }
+
+    fn restore_state(&mut self, snapshot: &dyn Any) {
+        if let Some(scope_manager) = snapshot.downcast_ref::<ScopeManager<JavaScript>>() {
+            self.restore_scope_manager(scope_manager.clone());
+        }
     }
 }
 

--- a/core/src/js/regex.rs
+++ b/core/src/js/regex.rs
@@ -27,7 +27,7 @@ use std::collections::HashSet;
 ///
 /// assert_eq!(linter.output, "var r = /ab+/i;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseRegex;
 
 impl ParseRegex {
@@ -176,7 +176,7 @@ impl<'a> RuleMut<'a> for ParseRegex {
 ///
 /// assert_eq!(linter.output, "var a = true;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RegexExec;
 
 impl RegexExec {
@@ -307,7 +307,7 @@ impl<'a> RuleMut<'a> for RegexExec {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 'Hello, world!1';");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RegexConcat;
 
 impl<'a> RuleMut<'a> for RegexConcat {

--- a/core/src/js/specials.rs
+++ b/core/src/js/specials.rs
@@ -9,7 +9,7 @@ use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
 
 /// Parse specials
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseSpecials;
 
 impl<'a> RuleMut<'a> for ParseSpecials {
@@ -80,7 +80,7 @@ impl<'a> RuleMut<'a> for ParseSpecials {
 /// assert_eq!(linter.output, "var x = 'undefined';");
 /// ```
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AddSubSpecials;
 
 impl<'a> RuleMut<'a> for AddSubSpecials {

--- a/core/src/js/strategy.rs
+++ b/core/src/js/strategy.rs
@@ -6,7 +6,7 @@ use crate::tree::BranchFlow::{Predictable, Unpredictable};
 use crate::tree::ControlFlow::{Break, Continue};
 use crate::tree::{ControlFlow, Node, Strategy};
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct JavaScriptStrategy;
 
 impl Strategy<JavaScript> for JavaScriptStrategy {

--- a/core/src/js/string.rs
+++ b/core/src/js/string.rs
@@ -12,7 +12,7 @@ use crate::tree::{ControlFlow, NodeMut};
 use log::{trace, warn};
 
 /// Parses JavaScript string literals into `Raw(Str(_))`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseString;
 
 impl<'a> RuleMut<'a> for ParseString {
@@ -147,7 +147,7 @@ fn unescaped_js_string(s: &str) -> String {
 ///
 /// assert_eq!(linter.output, "var x = 'e';");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CharAt;
 
 impl<'a> RuleMut<'a> for CharAt {
@@ -244,7 +244,7 @@ pub fn escape_js_string(s: &str) -> String {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 42; var y = -42;");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StringPlusMinus;
 
 impl<'a> RuleMut<'a> for StringPlusMinus {
@@ -312,7 +312,7 @@ impl<'a> RuleMut<'a> for StringPlusMinus {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 'Hello, world!1';");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Concat;
 
 impl<'a> RuleMut<'a> for Concat {
@@ -478,7 +478,7 @@ impl<'a> RuleMut<'a> for Concat {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = 'v';");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ToString;
 
 impl<'a> RuleMut<'a> for ToString {
@@ -609,7 +609,7 @@ impl<'a> RuleMut<'a> for ToString {
 /// tree.apply(&mut linter).unwrap();
 /// assert_eq!(linter.output, "var x = ['a', 'b'];");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Split;
 
 impl Split {

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -6,6 +6,7 @@ use crate::rule::RuleMut;
 use crate::scope::ScopeManager;
 use crate::tree::{BranchFlow, ControlFlow, Node, NodeMut};
 use log::trace;
+use std::any::Any;
 
 /// Var is a variable manager that will try to track
 /// static variable assignments and propagate them in the code
@@ -346,6 +347,16 @@ impl<'a> RuleMut<'a> for Var {
             _ => {}
         }
         Ok(())
+    }
+
+    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
+        Some(Box::new(self.snapshot_scope_manager()))
+    }
+
+    fn restore_state(&mut self, snapshot: &dyn Any) {
+        if let Some(scope_manager) = snapshot.downcast_ref::<ScopeManager<JavaScript>>() {
+            self.restore_scope_manager(scope_manager.clone());
+        }
     }
 }
 

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -38,6 +38,7 @@ use log::trace;
 ///
 /// assert_eq!(linter.output, "var a = 'hello'; console.log('hello');");
 /// ```
+#[derive(Clone)]
 pub struct Var {
     scope_manager: ScopeManager<JavaScript>,
 }

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -51,6 +51,18 @@ impl Default for Var {
 }
 
 impl Var {
+    pub fn from_scope_manager(scope_manager: ScopeManager<JavaScript>) -> Self {
+        Self { scope_manager }
+    }
+
+    pub fn snapshot_scope_manager(&self) -> ScopeManager<JavaScript> {
+        self.scope_manager.clone()
+    }
+
+    pub fn restore_scope_manager(&mut self, scope_manager: ScopeManager<JavaScript>) {
+        self.scope_manager = scope_manager;
+    }
+
     fn forget_assigned_var<T>(&mut self, node: &Node<T>) -> MinusOneResult<()> {
         for child in node.iter() {
             match child.kind() {
@@ -347,7 +359,6 @@ mod tests {
     use crate::js::var::Var;
 
     fn deobfuscate(input: &str) -> String {
-        // todo: same method on other js tests with logic scopes
         let mut tree = build_javascript_tree(input).unwrap();
         tree.apply_mut_with_strategy(
             &mut (

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -6,7 +6,6 @@ use crate::rule::RuleMut;
 use crate::scope::ScopeManager;
 use crate::tree::{BranchFlow, ControlFlow, Node, NodeMut};
 use log::trace;
-use std::any::Any;
 
 /// Var is a variable manager that will try to track
 /// static variable assignments and propagate them in the code
@@ -347,16 +346,6 @@ impl<'a> RuleMut<'a> for Var {
             _ => {}
         }
         Ok(())
-    }
-
-    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
-        Some(Box::new(self.snapshot_scope_manager()))
-    }
-
-    fn restore_state(&mut self, snapshot: &dyn Any) {
-        if let Some(scope_manager) = snapshot.downcast_ref::<ScopeManager<JavaScript>>() {
-            self.restore_scope_manager(scope_manager.clone());
-        }
     }
 }
 

--- a/core/src/ps/access.rs
+++ b/core/src/ps/access.rs
@@ -64,7 +64,7 @@ fn get_array_at_index(s: &[Value], index: i64) -> Option<&Value> {
 ///
 /// assert_eq!(ps_litter_view.output, "\"cba\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AccessString;
 
 impl<'a> RuleMut<'a> for AccessString {
@@ -128,7 +128,7 @@ impl<'a> RuleMut<'a> for AccessString {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AccessArray;
 
 impl<'a> RuleMut<'a> for AccessArray {
@@ -226,7 +226,7 @@ impl<'a> RuleMut<'a> for AccessArray {
 ///
 /// assert_eq!(ps_litter_view.output, "6");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AccessHashMap;
 
 impl<'a> RuleMut<'a> for AccessHashMap {

--- a/core/src/ps/array.rs
+++ b/core/src/ps/array.rs
@@ -36,7 +36,7 @@ use log::{trace, warn};
 ///
 /// assert_eq!(ps_litter_view.output, "\"abc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseArrayLiteral;
 
 impl<'a> RuleMut<'a> for ParseArrayLiteral {
@@ -109,7 +109,7 @@ impl<'a> RuleMut<'a> for ParseArrayLiteral {
 ///
 /// assert_eq!(ps_litter_view.output, "\"abc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseRange;
 
 impl<'a> RuleMut<'a> for ParseRange {
@@ -193,7 +193,7 @@ impl<'a> RuleMut<'a> for ParseRange {
 ///
 /// assert_eq!(ps_litter_view.output, "\"abc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ComputeArrayExpr;
 
 impl<'a> RuleMut<'a> for ComputeArrayExpr {
@@ -276,7 +276,7 @@ impl<'a> RuleMut<'a> for ComputeArrayExpr {
 ///
 /// assert_eq!(ps_litter_view.output, "\"fox\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AddArray;
 
 impl<'a> RuleMut<'a> for AddArray {

--- a/core/src/ps/bool.rs
+++ b/core/src/ps/bool.rs
@@ -30,7 +30,7 @@ use log::trace;
 ///
 /// assert_eq!(ps_litter_view.output, "$true");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseBool;
 
 impl<'a> RuleMut<'a> for ParseBool {
@@ -93,7 +93,7 @@ impl<'a> RuleMut<'a> for ParseBool {
 ///
 /// assert_eq!(ps_litter_view.output, "$false");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BoolAlgebra;
 
 impl<'a> RuleMut<'a> for BoolAlgebra {
@@ -175,7 +175,7 @@ impl<'a> RuleMut<'a> for BoolAlgebra {
 ///
 /// assert_eq!(ps_litter_view.output, "$true");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Comparison;
 
 impl<'a> RuleMut<'a> for Comparison {
@@ -213,7 +213,7 @@ impl<'a> RuleMut<'a> for Comparison {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Not;
 
 impl<'a> RuleMut<'a> for Not {

--- a/core/src/ps/cast.rs
+++ b/core/src/ps/cast.rs
@@ -8,7 +8,7 @@ use log::{trace, warn};
 
 /// Handle static cast operations
 /// For example [char]0x74 => 't'
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Cast;
 
 /// We will infer cast value using down to top exploring
@@ -227,7 +227,7 @@ impl<'a> RuleMut<'a> for Cast {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CastNull;
 
 impl<'a> RuleMut<'a> for CastNull {

--- a/core/src/ps/foreach.rs
+++ b/core/src/ps/foreach.rs
@@ -71,7 +71,7 @@ fn is_foreach_command<'a>(command: &Node<'a, Powershell>) -> bool {
 ///
 /// assert_eq!(ps_litter_view.output, "\"abc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PSItemInferrator;
 
 impl<'a> RuleMut<'a> for PSItemInferrator {
@@ -163,7 +163,7 @@ impl<'a> RuleMut<'a> for PSItemInferrator {
 ///
 /// assert_eq!(ps_litter_view.output, "\"zazbzc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ForEach;
 
 impl<'a> RuleMut<'a> for ForEach {

--- a/core/src/ps/forward.rs
+++ b/core/src/ps/forward.rs
@@ -7,7 +7,7 @@ use log::trace;
 
 /// The forward rule is use to forward
 /// inferedtype in the most simple case : where there is nothing to do
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Forward;
 
 /// Forward will just forward inferred type in case of very simple

--- a/core/src/ps/hash.rs
+++ b/core/src/ps/hash.rs
@@ -7,7 +7,7 @@ use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
 use std::collections::BTreeMap;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseHash;
 
 impl<'a> RuleMut<'a> for ParseHash {

--- a/core/src/ps/integer.rs
+++ b/core/src/ps/integer.rs
@@ -25,7 +25,7 @@ use log::{trace, warn};
 ///
 /// assert_eq!(ps_litter_view.output, "4 + 5");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseInt;
 
 impl<'a> RuleMut<'a> for ParseInt {
@@ -100,7 +100,7 @@ impl<'a> RuleMut<'a> for ParseInt {
 ///
 /// assert_eq!(ps_litter_view.output, "7");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AddInt;
 
 impl<'a> RuleMut<'a> for AddInt {
@@ -170,7 +170,7 @@ impl<'a> RuleMut<'a> for AddInt {
 ///
 /// assert_eq!(ps_litter_view.output, "1");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct MultInt;
 
 impl<'a> RuleMut<'a> for MultInt {

--- a/core/src/ps/join.rs
+++ b/core/src/ps/join.rs
@@ -38,7 +38,7 @@ use log::trace;
 ///
 /// assert_eq!(ps_litter_view.output, "\"invoke-expression\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct JoinComparison;
 
 impl<'a> RuleMut<'a> for JoinComparison {
@@ -115,7 +115,7 @@ impl<'a> RuleMut<'a> for JoinComparison {
 ///
 /// assert_eq!(ps_litter_view.output, "\"abc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct JoinStringMethod;
 
 impl<'a> RuleMut<'a> for JoinStringMethod {
@@ -218,7 +218,7 @@ impl<'a> RuleMut<'a> for JoinStringMethod {
 ///
 /// assert_eq!(ps_litter_view.output, "\"abc\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct JoinOperator;
 
 impl<'a> RuleMut<'a> for JoinOperator {

--- a/core/src/ps/linter.rs
+++ b/core/src/ps/linter.rs
@@ -38,6 +38,7 @@ fn is_inline<T>(node: &Node<T>) -> bool {
     node.get_parent_of_types(vec!["pipeline"]).is_some()
 }
 
+#[derive(Clone)]
 pub struct Linter {
     pub output: String,
     tab: Vec<String>,
@@ -457,7 +458,7 @@ impl Linter {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RemoveCode {
     source: String,
     pub output: String,
@@ -486,7 +487,7 @@ impl RemoveCode {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RemoveComment {
     manager: RemoveCode,
 }
@@ -523,6 +524,7 @@ impl<'a> Rule<'a> for RemoveComment {
     }
 }
 
+#[derive(Clone)]
 pub struct RemoveUnusedVar {
     rule: UnusedVar,
     manager: RemoveCode,

--- a/core/src/ps/loops.rs
+++ b/core/src/ps/loops.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use log::trace;
 
+#[derive(Clone)]
 struct IteratorVariable {
     name: String,
     value: Value,
@@ -56,7 +57,7 @@ impl IteratorVariable {
 ///
 /// assert_eq!(ps_litter_view.output, "");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ForStatementCondition {
     loop_id: Option<usize>,
 }
@@ -139,7 +140,7 @@ impl<'a> RuleMut<'a> for ForStatementCondition {
 ///
 /// assert_eq!(clean.trim(), "42");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ForStatementFlowControl {
     iterators: Vec<IteratorVariable>,
     loop_id: Option<usize>,

--- a/core/src/ps/method.rs
+++ b/core/src/ps/method.rs
@@ -31,7 +31,7 @@ use log::{trace, warn};
 ///
 /// assert_eq!(ps_litter_view.output, "3");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Length;
 
 impl<'a> RuleMut<'a> for Length {
@@ -117,7 +117,7 @@ impl<'a> RuleMut<'a> for Length {
 ///
 /// assert_eq!(ps_litter_view.output, "\"foo\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct DecodeBase64;
 
 impl<'a> RuleMut<'a> for DecodeBase64 {
@@ -248,7 +248,7 @@ impl<'a> RuleMut<'a> for DecodeBase64 {
 ///
 /// assert_eq!(ps_litter_view.output, "\"foo\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct FromUTF;
 
 impl<'a> RuleMut<'a> for FromUTF {

--- a/core/src/ps/mod.rs
+++ b/core/src/ps/mod.rs
@@ -217,7 +217,7 @@ impl<'a> RuleMut<'a> for PowershellRuleSet<'a> {
         &mut self,
         node: &mut crate::tree::NodeMut<'a, Self::Language>,
         flow: crate::tree::ControlFlow,
-        context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
         self.ruleset.enter_with_context(node, flow, context)
     }
@@ -226,7 +226,7 @@ impl<'a> RuleMut<'a> for PowershellRuleSet<'a> {
         &mut self,
         node: &mut crate::tree::NodeMut<'a, Self::Language>,
         flow: crate::tree::ControlFlow,
-        context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
         self.ruleset.leave_with_context(node, flow, context)
     }

--- a/core/src/ps/mod.rs
+++ b/core/src/ps/mod.rs
@@ -18,7 +18,7 @@ use crate::ps::string::{
 use crate::ps::switch::Switch;
 use crate::ps::typing::ParseType;
 use crate::ps::var::{StaticVar, Var};
-use crate::rule::{RuleMut, RuleSet, RuleSetBuilderType};
+use crate::rule::{RuleExecutionContext, RuleMut, RuleSet, RuleSetBuilderType};
 use crate::tree::{HashMapStorage, Storage, Tree};
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -192,6 +192,10 @@ impl_powershell_ruleset!(
 impl<'a> RuleMut<'a> for PowershellRuleSet<'a> {
     type Language = Powershell;
 
+    fn active_rule_names(&self) -> Vec<String> {
+        self.ruleset.active_rule_names()
+    }
+
     fn enter(
         &mut self,
         node: &mut crate::tree::NodeMut<'a, Self::Language>,
@@ -206,6 +210,24 @@ impl<'a> RuleMut<'a> for PowershellRuleSet<'a> {
         flow: crate::tree::ControlFlow,
     ) -> MinusOneResult<()> {
         self.ruleset.leave(node, flow)
+    }
+
+    fn enter_with_context(
+        &mut self,
+        node: &mut crate::tree::NodeMut<'a, Self::Language>,
+        flow: crate::tree::ControlFlow,
+        context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        self.ruleset.enter_with_context(node, flow, context)
+    }
+
+    fn leave_with_context(
+        &mut self,
+        node: &mut crate::tree::NodeMut<'a, Self::Language>,
+        flow: crate::tree::ControlFlow,
+        context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        self.ruleset.leave_with_context(node, flow, context)
     }
 }
 

--- a/core/src/ps/mod.rs
+++ b/core/src/ps/mod.rs
@@ -117,6 +117,7 @@ pub enum Powershell {
     Unknown,
 }
 
+#[derive(Clone)]
 pub struct PowershellRuleSet<'a> {
     ruleset: RuleSet<'a, Powershell>,
 }

--- a/core/src/ps/static.rs
+++ b/core/src/ps/static.rs
@@ -27,7 +27,7 @@ pub trait Detection {
     fn get_nodes(&self) -> &Vec<Pattern>;
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Static;
 
 impl<'a> RuleMut<'a> for Static {
@@ -113,7 +113,7 @@ impl<'a> RuleMut<'a> for Static {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StaticArray {
     detected_nodes : Vec<Pattern>
 }
@@ -142,7 +142,7 @@ impl Detection for StaticArray {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StaticFormat {
     detected_nodes : Vec<Pattern>
 }

--- a/core/src/ps/strategy.rs
+++ b/core/src/ps/strategy.rs
@@ -7,7 +7,7 @@ use crate::tree::ControlFlow::{Break, Continue};
 use crate::tree::{ControlFlow, Node, Strategy};
 use log::warn;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PowershellStrategy;
 
 impl Strategy<Powershell> for PowershellStrategy {

--- a/core/src/ps/string.rs
+++ b/core/src/ps/string.rs
@@ -7,7 +7,7 @@ use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseString;
 
 impl<'a> RuleMut<'a> for ParseString {
@@ -108,7 +108,7 @@ impl<'a> RuleMut<'a> for ParseString {
 ///
 /// assert_eq!(ps_litter_view.output, "\"foobar\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ConcatString;
 
 impl<'a> RuleMut<'a> for ConcatString {
@@ -143,7 +143,7 @@ impl<'a> RuleMut<'a> for ConcatString {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StringReplaceMethod;
 
 impl<'a> RuleMut<'a> for StringReplaceMethod {
@@ -200,7 +200,7 @@ impl<'a> RuleMut<'a> for StringReplaceMethod {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StringReplaceOp;
 
 impl<'a> RuleMut<'a> for StringReplaceOp {
@@ -268,7 +268,7 @@ impl<'a> RuleMut<'a> for StringReplaceOp {
 ///
 /// assert_eq!(ps_litter_view.output, "\"hello world\"");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct FormatString;
 
 impl<'a> RuleMut<'a> for FormatString {
@@ -313,7 +313,7 @@ impl<'a> RuleMut<'a> for FormatString {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StringSplitMethod;
 
 impl<'a> RuleMut<'a> for StringSplitMethod {

--- a/core/src/ps/switch.rs
+++ b/core/src/ps/switch.rs
@@ -30,11 +30,12 @@ use log::{trace, warn};
 ///
 /// assert_eq!(ps_litter_view.output, "2");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Switch {
     ctx: Vec<SwitchCtx>, // Holds last infered (or not) switch condition
 }
 
+#[derive(Clone)]
 struct SwitchCtx {
     condition: Option<Powershell>,
     predictable: bool,

--- a/core/src/ps/typing.rs
+++ b/core/src/ps/typing.rs
@@ -5,7 +5,7 @@ use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParseType;
 
 impl<'a> RuleMut<'a> for ParseType {

--- a/core/src/ps/var.rs
+++ b/core/src/ps/var.rs
@@ -37,6 +37,7 @@ use std::ops::Add;
 /// Write-Debug 4\
 /// ");
 /// ```
+#[derive(Clone)]
 pub struct Var {
     scope_manager: ScopeManager<Powershell>,
 }
@@ -691,7 +692,7 @@ fn assign_handler(
 /// Write-Debug 4\
 /// ");
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StaticVar;
 
 impl<'a> RuleMut<'a> for StaticVar {
@@ -742,7 +743,7 @@ impl<'a> RuleMut<'a> for StaticVar {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct UnusedVar {
     pub vars: HashMap<String, bool>,
 }

--- a/core/src/rule.rs
+++ b/core/src/rule.rs
@@ -1,5 +1,6 @@
 use crate::error::MinusOneResult;
 use crate::tree::{ControlFlow, Node, NodeMut};
+use dyn_clone::DynClone;
 use log::warn;
 
 pub struct RuleExecutionContext<'a> {
@@ -7,7 +8,7 @@ pub struct RuleExecutionContext<'a> {
     pub recursion_depth: usize,
 }
 
-pub trait RuleMut<'a> {
+pub trait RuleMut<'a>: DynClone {
     type Language;
 
     fn active_rule_names(&self) -> Vec<String> {
@@ -45,6 +46,8 @@ pub trait RuleMut<'a> {
     }
 }
 
+dyn_clone::clone_trait_object!(<'a, T> RuleMut<'a, Language = T>);
+
 /// Rule that will not change the node component
 /// Use for displaying or statistic
 /// The top down exploring is handling by the enter function
@@ -58,6 +61,19 @@ pub trait Rule<'a> {
 pub struct RuleSet<'a, T> {
     rule_names: Vec<String>,
     rules: Vec<Box<dyn RuleMut<'a, Language = T>>>,
+}
+
+impl<'a, T> Clone for RuleSet<'a, T> {
+    fn clone(&self) -> Self {
+        RuleSet {
+            rule_names: self.rule_names.clone(),
+            rules: self
+                .rules
+                .iter()
+                .map(|r| dyn_clone::clone_box(&**r))
+                .collect(),
+        }
+    }
 }
 
 impl<'a, T> RuleSet<'a, T> {
@@ -193,7 +209,7 @@ impl<'a, T> RuleMut<'a> for RuleSet<'a, T> {
 macro_rules! impl_data {
     ( $($ty:ident),* ) => {
         impl<'a, Data, $($ty),*> RuleMut<'a> for ( $( $ty , )* )
-            where $( $ty : RuleMut<'a, Language=Data>),*
+            where $( $ty : RuleMut<'a, Language=Data> + Clone),*
             {
                 type Language = Data;
 

--- a/core/src/rule.rs
+++ b/core/src/rule.rs
@@ -2,18 +2,47 @@ use crate::error::MinusOneResult;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::warn;
 
+pub struct RuleExecutionContext<'a> {
+    pub other_rules: &'a [String],
+    pub recursion_depth: usize,
+}
+
 pub trait RuleMut<'a> {
     type Language;
+
+    fn active_rule_names(&self) -> Vec<String> {
+        vec![]
+    }
+
     fn enter(
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
     ) -> MinusOneResult<()>;
+
+    fn enter_with_context(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        flow: ControlFlow,
+        _context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        self.enter(node, flow)
+    }
+
     fn leave(
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
     ) -> MinusOneResult<()>;
+
+    fn leave_with_context(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        flow: ControlFlow,
+        _context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        self.leave(node, flow)
+    }
 }
 
 /// Rule that will not change the node component
@@ -27,6 +56,7 @@ pub trait Rule<'a> {
 }
 
 pub struct RuleSet<'a, T> {
+    rule_names: Vec<String>,
     rules: Vec<Box<dyn RuleMut<'a, Language = T>>>,
 }
 
@@ -59,17 +89,19 @@ impl<'a, T> RuleSet<'a, T> {
             .filter(|s| full_names.contains(s))
             .collect();
 
-        Self {
-            rules: full_names
-                .iter()
-                .zip(full_rules)
-                .filter(|(name, _)| match &ctx {
-                    RuleSetBuilderType::WithRules(_) => low_input.contains(name),
-                    RuleSetBuilderType::WithoutRules(_) => !low_input.contains(name),
-                })
-                .map(|(_, rule)| rule)
-                .collect(),
-        }
+        let selected: Vec<(String, Box<dyn RuleMut<'a, Language = T>>)> = full_names
+            .into_iter()
+            .zip(full_rules)
+            .filter(|(name, _)| match &ctx {
+                RuleSetBuilderType::WithRules(_) => low_input.contains(name),
+                RuleSetBuilderType::WithoutRules(_) => !low_input.contains(name),
+            })
+            .collect();
+
+        let (rule_names, rules): (Vec<String>, Vec<Box<dyn RuleMut<'a, Language = T>>>) =
+            selected.into_iter().unzip();
+
+        Self { rule_names, rules }
     }
 }
 
@@ -81,6 +113,10 @@ pub enum RuleSetBuilderType<'a> {
 impl<'a, T> RuleMut<'a> for RuleSet<'a, T> {
     type Language = T;
 
+    fn active_rule_names(&self) -> Vec<String> {
+        self.rule_names.clone()
+    }
+
     fn enter(
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
@@ -89,12 +125,68 @@ impl<'a, T> RuleMut<'a> for RuleSet<'a, T> {
         self.rules.iter_mut().try_for_each(|r| r.enter(node, flow))
     }
 
+    fn enter_with_context(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        flow: ControlFlow,
+        context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        let rule_names = self.rule_names.clone();
+
+        self.rules
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(idx, rule)| {
+                let other_rules: Vec<String> = rule_names
+                    .iter()
+                    .enumerate()
+                    .filter(|(name_idx, _)| *name_idx != idx)
+                    .map(|(_, name)| name.clone())
+                    .collect();
+
+                let nested_context = RuleExecutionContext {
+                    other_rules: &other_rules,
+                    recursion_depth: context.recursion_depth,
+                };
+
+                rule.enter_with_context(node, flow, &nested_context)
+            })
+    }
+
     fn leave(
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
     ) -> MinusOneResult<()> {
         self.rules.iter_mut().try_for_each(|r| r.leave(node, flow))
+    }
+
+    fn leave_with_context(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        flow: ControlFlow,
+        context: &RuleExecutionContext,
+    ) -> MinusOneResult<()> {
+        let rule_names = self.rule_names.clone();
+
+        self.rules
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(idx, rule)| {
+                let other_rules: Vec<String> = rule_names
+                    .iter()
+                    .enumerate()
+                    .filter(|(name_idx, _)| *name_idx != idx)
+                    .map(|(_, name)| name.clone())
+                    .collect();
+
+                let nested_context = RuleExecutionContext {
+                    other_rules: &other_rules,
+                    recursion_depth: context.recursion_depth,
+                };
+
+                rule.leave_with_context(node, flow, &nested_context)
+            })
     }
 }
 
@@ -105,6 +197,15 @@ macro_rules! impl_data {
             {
                 type Language = Data;
 
+                fn active_rule_names(&self) -> Vec<String> {
+                    let mut names = Vec::new();
+                    $(
+                        ${ignore($ty)}
+                        names.extend(self.${index()}.active_rule_names());
+                    )*
+                    names
+                }
+
                 fn enter(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow) -> MinusOneResult<()>{
                     $(
                         ${ignore($ty)}
@@ -113,10 +214,26 @@ macro_rules! impl_data {
                     Ok(())
                 }
 
+                fn enter_with_context(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow, context: &RuleExecutionContext) -> MinusOneResult<()>{
+                    $(
+                        ${ignore($ty)}
+                        self.${index()}.enter_with_context(node, flow, context)?;
+                    )*
+                    Ok(())
+                }
+
                 fn leave(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow) -> MinusOneResult<()>{
                     $(
                         ${ignore($ty)}
                         self.${index()}.leave(node, flow)?;
+                    )*
+                    Ok(())
+                }
+
+                fn leave_with_context(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow, context: &RuleExecutionContext) -> MinusOneResult<()>{
+                    $(
+                        ${ignore($ty)}
+                        self.${index()}.leave_with_context(node, flow, context)?;
                     )*
                     Ok(())
                 }

--- a/core/src/rule.rs
+++ b/core/src/rule.rs
@@ -2,7 +2,6 @@ use crate::error::MinusOneResult;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use dyn_clone::DynClone;
 use log::warn;
-use std::any::Any;
 
 pub struct RuleReference<'ctx, 'a, T> {
     pub name: &'ctx str,
@@ -50,12 +49,6 @@ pub trait RuleMut<'a>: DynClone {
     ) -> MinusOneResult<()> {
         self.leave(node, flow)
     }
-
-    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
-        None
-    }
-
-    fn restore_state(&mut self, _snapshot: &dyn Any) {}
 }
 
 dyn_clone::clone_trait_object!(<'a, T> RuleMut<'a, Language = T>);
@@ -71,8 +64,8 @@ pub trait Rule<'a> {
 }
 
 pub struct RuleSet<'a, T> {
-    rule_names: Vec<String>,
-    rules: Vec<Box<dyn RuleMut<'a, Language = T>>>,
+    pub rule_names: Vec<String>,
+    pub rules: Vec<Box<dyn RuleMut<'a, Language = T>>>,
 }
 
 impl<'a, T> Clone for RuleSet<'a, T> {

--- a/core/src/rule.rs
+++ b/core/src/rule.rs
@@ -2,9 +2,15 @@ use crate::error::MinusOneResult;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use dyn_clone::DynClone;
 use log::warn;
+use std::any::Any;
 
-pub struct RuleExecutionContext<'a> {
-    pub other_rules: &'a [String],
+pub struct RuleReference<'ctx, 'a, T> {
+    pub name: &'ctx str,
+    pub rule: &'ctx (dyn RuleMut<'a, Language = T> + 'static),
+}
+
+pub struct RuleExecutionContext<'ctx, 'a, T> {
+    pub other_rules: &'ctx [RuleReference<'ctx, 'a, T>],
     pub recursion_depth: usize,
 }
 
@@ -25,7 +31,7 @@ pub trait RuleMut<'a>: DynClone {
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
-        _context: &RuleExecutionContext,
+        _context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
         self.enter(node, flow)
     }
@@ -40,10 +46,16 @@ pub trait RuleMut<'a>: DynClone {
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
-        _context: &RuleExecutionContext,
+        _context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
         self.leave(node, flow)
     }
+
+    fn snapshot_state(&self) -> Option<Box<dyn Any>> {
+        None
+    }
+
+    fn restore_state(&mut self, _snapshot: &dyn Any) {}
 }
 
 dyn_clone::clone_trait_object!(<'a, T> RuleMut<'a, Language = T>);
@@ -119,6 +131,23 @@ impl<'a, T> RuleSet<'a, T> {
 
         Self { rule_names, rules }
     }
+
+    pub fn from_parts(
+        rule_names: Vec<String>,
+        rules: Vec<Box<dyn RuleMut<'a, Language = T>>>,
+    ) -> Self {
+        Self { rule_names, rules }
+    }
+
+    pub fn for_each_rule_mut(
+        &mut self,
+        mut handler: impl FnMut(&str, &mut dyn RuleMut<'a, Language = T>),
+    ) {
+        self.rule_names
+            .iter()
+            .zip(self.rules.iter_mut())
+            .for_each(|(name, rule)| handler(name.as_str(), rule.as_mut()));
+    }
 }
 
 pub enum RuleSetBuilderType<'a> {
@@ -145,28 +174,45 @@ impl<'a, T> RuleMut<'a> for RuleSet<'a, T> {
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
-        context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
-        let rule_names = self.rule_names.clone();
+        let rule_count = self.rules.len();
 
-        self.rules
-            .iter_mut()
-            .enumerate()
-            .try_for_each(|(idx, rule)| {
-                let other_rules: Vec<String> = rule_names
-                    .iter()
-                    .enumerate()
-                    .filter(|(name_idx, _)| *name_idx != idx)
-                    .map(|(_, name)| name.clone())
-                    .collect();
+        for idx in 0..rule_count {
+            let (left_rules, right_rules) = self.rules.split_at_mut(idx);
+            let (current_rule, right_rules) =
+                right_rules.split_first_mut().expect("valid rule index");
 
-                let nested_context = RuleExecutionContext {
-                    other_rules: &other_rules,
-                    recursion_depth: context.recursion_depth,
-                };
+            let (left_names, right_names) = self.rule_names.split_at(idx);
+            let (_current_name, right_names) = right_names.split_first().expect("valid rule index");
 
-                rule.enter_with_context(node, flow, &nested_context)
-            })
+            let other_rules: Vec<RuleReference<'_, 'a, T>> = left_names
+                .iter()
+                .zip(left_rules.iter())
+                .map(|(name, rule)| RuleReference {
+                    name,
+                    rule: &**rule,
+                })
+                .chain(
+                    right_names
+                        .iter()
+                        .zip(right_rules.iter())
+                        .map(|(name, rule)| RuleReference {
+                            name,
+                            rule: &**rule,
+                        }),
+                )
+                .collect();
+
+            let nested_context = RuleExecutionContext {
+                other_rules: &other_rules,
+                recursion_depth: context.recursion_depth,
+            };
+
+            current_rule.enter_with_context(node, flow, &nested_context)?;
+        }
+
+        Ok(())
     }
 
     fn leave(
@@ -181,28 +227,45 @@ impl<'a, T> RuleMut<'a> for RuleSet<'a, T> {
         &mut self,
         node: &mut NodeMut<'a, Self::Language>,
         flow: ControlFlow,
-        context: &RuleExecutionContext,
+        context: &RuleExecutionContext<'_, 'a, Self::Language>,
     ) -> MinusOneResult<()> {
-        let rule_names = self.rule_names.clone();
+        let rule_count = self.rules.len();
 
-        self.rules
-            .iter_mut()
-            .enumerate()
-            .try_for_each(|(idx, rule)| {
-                let other_rules: Vec<String> = rule_names
-                    .iter()
-                    .enumerate()
-                    .filter(|(name_idx, _)| *name_idx != idx)
-                    .map(|(_, name)| name.clone())
-                    .collect();
+        for idx in 0..rule_count {
+            let (left_rules, right_rules) = self.rules.split_at_mut(idx);
+            let (current_rule, right_rules) =
+                right_rules.split_first_mut().expect("valid rule index");
 
-                let nested_context = RuleExecutionContext {
-                    other_rules: &other_rules,
-                    recursion_depth: context.recursion_depth,
-                };
+            let (left_names, right_names) = self.rule_names.split_at(idx);
+            let (_current_name, right_names) = right_names.split_first().expect("valid rule index");
 
-                rule.leave_with_context(node, flow, &nested_context)
-            })
+            let other_rules: Vec<RuleReference<'_, 'a, T>> = left_names
+                .iter()
+                .zip(left_rules.iter())
+                .map(|(name, rule)| RuleReference {
+                    name,
+                    rule: &**rule,
+                })
+                .chain(
+                    right_names
+                        .iter()
+                        .zip(right_rules.iter())
+                        .map(|(name, rule)| RuleReference {
+                            name,
+                            rule: &**rule,
+                        }),
+                )
+                .collect();
+
+            let nested_context = RuleExecutionContext {
+                other_rules: &other_rules,
+                recursion_depth: context.recursion_depth,
+            };
+
+            current_rule.leave_with_context(node, flow, &nested_context)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -230,7 +293,7 @@ macro_rules! impl_data {
                     Ok(())
                 }
 
-                fn enter_with_context(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow, context: &RuleExecutionContext) -> MinusOneResult<()>{
+                fn enter_with_context(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow, context: &RuleExecutionContext<'_, 'a, Self::Language>) -> MinusOneResult<()>{
                     $(
                         ${ignore($ty)}
                         self.${index()}.enter_with_context(node, flow, context)?;
@@ -246,7 +309,7 @@ macro_rules! impl_data {
                     Ok(())
                 }
 
-                fn leave_with_context(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow, context: &RuleExecutionContext) -> MinusOneResult<()>{
+                fn leave_with_context(&mut self, node : &mut NodeMut<'a, Self::Language>, flow: ControlFlow, context: &RuleExecutionContext<'_, 'a, Self::Language>) -> MinusOneResult<()>{
                     $(
                         ${ignore($ty)}
                         self.${index()}.leave_with_context(node, flow, context)?;

--- a/core/src/scope.rs
+++ b/core/src/scope.rs
@@ -120,6 +120,7 @@ impl<T: Clone> Scope<T> {
     }
 }
 
+#[derive(Clone)]
 pub struct ScopeManager<T: Clone> {
     scopes: Vec<Scope<T>>,
 }

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -463,7 +463,7 @@ impl<'a, T> NodeMut<'a, T> {
     /// use minusone::error::MinusOneResult;
     ///
     ///
-    /// #[derive(Default)]
+    /// #[derive(Default, Clone)]
     /// pub struct MyRule;
     /// // This rule will only try to parse the text of each token to recognize a u32
     /// impl<'a> RuleMut<'a> for MyRule {
@@ -577,7 +577,7 @@ impl<'a, T> NodeMut<'a, T> {
     /// use minusone::tree::BranchFlow::Predictable;
     ///
     ///
-    /// #[derive(Default)]
+    /// #[derive(Default, Clone)]
     /// pub struct MyRule;
     /// // This rule will only try to parse the text of each token to recognize a u32
     /// impl<'a> RuleMut<'a> for MyRule {
@@ -688,7 +688,7 @@ impl<'a, T> NodeMut<'a, T> {
     /// use minusone::tree::BranchFlow::Predictable;
     ///
     ///
-    /// #[derive(Default)]
+    /// #[derive(Default, Clone)]
     /// pub struct MyRule;
     /// // This rule will only try to parse the text of each token to recognize a u32
     /// impl<'a> RuleMut<'a> for MyRule {
@@ -1117,7 +1117,7 @@ where
 
     pub fn apply_mut<'b>(
         &'b mut self,
-        rule: &mut (impl RuleMut<'b, Language = S::Component> + Sized),
+        rule: &mut (impl RuleMut<'b, Language = S::Component> + Sized + Clone),
     ) -> MinusOneResult<()> {
         let mut node = NodeMut::new(self.tree_sitter.root_node(), self.source, &mut self.storage);
         node.apply(rule)
@@ -1125,7 +1125,7 @@ where
 
     pub fn apply_mut_with_strategy<'b>(
         &'b mut self,
-        rule: &mut (impl RuleMut<'b, Language = S::Component> + Sized),
+        rule: &mut (impl RuleMut<'b, Language = S::Component> + Sized + Clone),
         strategy: impl Strategy<S::Component>,
     ) -> MinusOneResult<()> {
         let mut node = NodeMut::new(self.tree_sitter.root_node(), self.source, &mut self.storage);
@@ -1138,7 +1138,7 @@ where
 
     pub fn apply<'b>(
         &'b self,
-        rule: &mut (impl Rule<'b, Language = S::Component> + Sized),
+        rule: &mut (impl Rule<'b, Language = S::Component> + Sized + Clone),
     ) -> MinusOneResult<()> {
         let node = Node::new(self.tree_sitter.root_node(), self.source, &self.storage);
         node.apply(rule)

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, MinusOneResult};
-use crate::rule::{Rule, RuleMut};
+use crate::rule::{Rule, RuleExecutionContext, RuleMut};
 use log::{error, trace, warn};
 use std::collections::HashMap;
 use std::ops;
@@ -498,6 +498,7 @@ impl<'a, T> NodeMut<'a, T> {
     pub fn apply(&mut self, rule: &mut impl RuleMut<'a, Language = T>) -> MinusOneResult<()> {
         // Stack use to call 'leave' method when all children are handled
         let mut stack: Vec<(TreeNode, usize)> = vec![];
+        let other_rules = rule.active_rule_names();
 
         for node in traverse(self.inner.walk(), Order::Pre) {
             match node.kind() {
@@ -513,8 +514,16 @@ impl<'a, T> NodeMut<'a, T> {
             // compute strategy
 
             stack.push((node, node.child_count()));
+            let context = RuleExecutionContext {
+                other_rules: &other_rules,
+                recursion_depth: stack.len() - 1,
+            };
 
-            rule.enter(self, ControlFlow::Continue(BranchFlow::Unpredictable))?;
+            rule.enter_with_context(
+                self,
+                ControlFlow::Continue(BranchFlow::Unpredictable),
+                &context,
+            )?;
 
             // clean stack
             loop {
@@ -532,8 +541,16 @@ impl<'a, T> NodeMut<'a, T> {
                 }
 
                 self.inner = head_element.0;
+                let context = RuleExecutionContext {
+                    other_rules: &other_rules,
+                    recursion_depth: stack.len() - 1,
+                };
 
-                rule.leave(self, ControlFlow::Continue(BranchFlow::Unpredictable))?;
+                rule.leave_with_context(
+                    self,
+                    ControlFlow::Continue(BranchFlow::Unpredictable),
+                    &context,
+                )?;
 
                 stack.pop();
 
@@ -610,6 +627,18 @@ impl<'a, T> NodeMut<'a, T> {
         strategy: &impl Strategy<T>,
         flow: ControlFlow,
     ) -> MinusOneResult<()> {
+        let other_rules = rule.active_rule_names();
+        self.apply_with_strategy_recurcive_internal(rule, strategy, flow, &other_rules, 0)
+    }
+
+    fn apply_with_strategy_recurcive_internal(
+        &mut self,
+        rule: &mut impl RuleMut<'a, Language = T>,
+        strategy: &impl Strategy<T>,
+        flow: ControlFlow,
+        other_rules: &[String],
+        recursion_depth: usize,
+    ) -> MinusOneResult<()> {
         let mut computed_flow = flow;
         computed_flow = computed_flow | strategy.control(self.view())?;
 
@@ -617,17 +646,28 @@ impl<'a, T> NodeMut<'a, T> {
             return Ok(());
         }
 
-        rule.enter(self, computed_flow)?;
+        let context = RuleExecutionContext {
+            other_rules,
+            recursion_depth,
+        };
+
+        rule.enter_with_context(self, computed_flow, &context)?;
 
         let mut cursor = self.inner.walk();
         let current_node = self.inner;
         for child in self.inner.children(&mut cursor) {
             self.inner = child;
-            self.apply_with_strategy(rule, strategy, computed_flow)?;
+            self.apply_with_strategy_recurcive_internal(
+                rule,
+                strategy,
+                computed_flow,
+                other_rules,
+                recursion_depth + 1,
+            )?;
         }
 
         self.inner = current_node;
-        rule.leave(self, computed_flow)?;
+        rule.leave_with_context(self, computed_flow, &context)?;
         Ok(())
     }
 
@@ -701,6 +741,7 @@ impl<'a, T> NodeMut<'a, T> {
         let mut control_flow = flow;
         // Stack use to call 'leave' method when all children are handled
         let mut stack: Vec<(TreeNode, usize, ControlFlow)> = vec![];
+        let other_rules = rule.active_rule_names();
 
         for node in traverse(self.inner.walk(), Order::Pre) {
             match node.kind() {
@@ -717,11 +758,15 @@ impl<'a, T> NodeMut<'a, T> {
             // compute strategy
 
             stack.push((node, node.child_count(), control_flow));
+            let context = RuleExecutionContext {
+                other_rules: &other_rules,
+                recursion_depth: stack.len() - 1,
+            };
 
             control_flow = control_flow | strategy.control(self.view())?;
 
             if control_flow != ControlFlow::Break {
-                rule.enter(self, control_flow)?;
+                rule.enter_with_context(self, control_flow, &context)?;
             }
 
             // clean stack
@@ -740,9 +785,13 @@ impl<'a, T> NodeMut<'a, T> {
                 }
 
                 self.inner = head_element.0;
+                let context = RuleExecutionContext {
+                    other_rules: &other_rules,
+                    recursion_depth: stack.len() - 1,
+                };
 
                 if control_flow != ControlFlow::Break {
-                    rule.leave(self, control_flow)?;
+                    rule.leave_with_context(self, control_flow, &context)?;
                 }
 
                 control_flow = head_element.2;
@@ -910,7 +959,7 @@ impl<'a, T> Node<'a, T> {
         }
     }
 
-    fn apply(&self, rule: &mut impl Rule<'a, Language = T>) -> MinusOneResult<()> {
+    pub fn apply(&self, rule: &mut impl Rule<'a, Language = T>) -> MinusOneResult<()> {
         let mut is_visiting = true;
         // Stack use to call 'leave' method when all children are handled
         let mut stack: Vec<(TreeNode, usize, bool)> = vec![];

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -498,7 +498,7 @@ impl<'a, T> NodeMut<'a, T> {
     pub fn apply(&mut self, rule: &mut impl RuleMut<'a, Language = T>) -> MinusOneResult<()> {
         // Stack use to call 'leave' method when all children are handled
         let mut stack: Vec<(TreeNode, usize)> = vec![];
-        let other_rules = rule.active_rule_names();
+        let other_rules = [];
 
         for node in traverse(self.inner.walk(), Order::Pre) {
             match node.kind() {
@@ -627,7 +627,7 @@ impl<'a, T> NodeMut<'a, T> {
         strategy: &impl Strategy<T>,
         flow: ControlFlow,
     ) -> MinusOneResult<()> {
-        let other_rules = rule.active_rule_names();
+        let other_rules = [];
         self.apply_with_strategy_recurcive_internal(rule, strategy, flow, &other_rules, 0)
     }
 
@@ -636,7 +636,7 @@ impl<'a, T> NodeMut<'a, T> {
         rule: &mut impl RuleMut<'a, Language = T>,
         strategy: &impl Strategy<T>,
         flow: ControlFlow,
-        other_rules: &[String],
+        other_rules: &[crate::rule::RuleReference<'_, 'a, T>],
         recursion_depth: usize,
     ) -> MinusOneResult<()> {
         let mut computed_flow = flow;
@@ -741,7 +741,7 @@ impl<'a, T> NodeMut<'a, T> {
         let mut control_flow = flow;
         // Stack use to call 'leave' method when all children are handled
         let mut stack: Vec<(TreeNode, usize, ControlFlow)> = vec![];
-        let other_rules = rule.active_rule_names();
+        let other_rules = [];
 
         for node in traverse(self.inner.walk(), Order::Pre) {
             match node.kind() {

--- a/crates/minusone-cli/src/utils.rs
+++ b/crates/minusone-cli/src/utils.rs
@@ -14,6 +14,7 @@ pub(crate) fn run_deobf<B: DeobfuscationBackend>(
 ) -> MinusOneResult<()>
 where
     <B as DeobfuscationBackend>::Language: Debug,
+    <B as DeobfuscationBackend>::Language: Clone,
 {
     let cleaned = DeobfuscateEngine::<B>::remove_extra(source)?;
 


### PR DESCRIPTION
The major issue is that I had to implement a small unsafe part to change the lifetimes on the cloned rules. It's because `dyn_clone` and object safe traits don't support that on trait objects so rust is stuck, it sees `'a`, it needs `'b`, then it refuses

Even though the types say `'a` vs `'b`, at runtime there but as far as I understand, there is no difference. The rule's fields are all owned, no pointer inside the rule actually points into the outer tree. Transmuting `'a` -> `'b` only changes what Rust's type checker believes, not what's in memory

Let me know if you find a better solution and/or if I misunderstood something in my explanation

Also, I had to make all the rules clonable, but I discussed this with @dolphinau and it seems fine