### PR TITLE
Added switch case reduction

### DIFF
--- a/core/src/js/deadcode.rs
+++ b/core/src/js/deadcode.rs
@@ -711,10 +711,51 @@ mod test_js_deadcode {
     }
 
     #[test]
-    fn test_keep_switch_without_break_fallthrough() {
+    fn test_simplify_switch_with_fallthrough_until_switch_end() {
         assert_eq!(
             clean("switch (1) { case 1: a(); case 2: b(); break; default: c(); }"),
-            "switch (1) { case 1: a(); case 2: b(); break; default: c(); }"
+            "a(); b();"
+        );
+    }
+
+    #[test]
+    fn test_simplify_switch_with_fallthrough_to_the_end() {
+        assert_eq!(
+            clean(
+                "switch (2) {
+                        case 1:
+                            console.log('no');
+                            break;
+                        case 2:
+                            console.log('yes');
+                        case 3:
+                            console.log('yes');
+                        default:
+                            console.log('yes');
+                    }"
+            ),
+            "console.log('yes'); console.log('yes'); console.log('yes');"
+        );
+    }
+
+    #[test]
+    fn test_simplify_switch_with_fallthrough_until_late_break() {
+        assert_eq!(
+            clean(
+                "switch (2) {
+                        case 1:
+                            console.log('no');
+                            break;
+                        case 2:
+                            console.log('yes');
+                        case 3:
+                            console.log('yes');
+                            break
+                        default:
+                            console.log('no');
+                    }"
+            ),
+            "console.log('yes'); console.log('yes');"
         );
     }
 

--- a/core/src/js/deadcode.rs
+++ b/core/src/js/deadcode.rs
@@ -1,4 +1,5 @@
 use crate::error::MinusOneResult;
+use crate::js::r#switch::simplify_switch_statement_text;
 use crate::rule::Rule;
 use crate::tree::Node;
 use log::trace;
@@ -497,6 +498,18 @@ impl<'a> Rule<'a> for RemoveUnusedVar {
                     }
                 }
             }
+            "switch_statement" => {
+                if let Some(replacement) = simplify_switch_statement_text(node) {
+                    if replacement.is_empty() {
+                        trace!("RemoveUnusedVar: removing empty deterministic switch");
+                        self.remove_node(node)?;
+                    } else {
+                        trace!("RemoveUnusedVar: simplifying deterministic switch");
+                        self.replace_node_with_text(node, &replacement)?;
+                    }
+                    return Ok(false);
+                }
+            }
             _ => {}
         }
         Ok(true)
@@ -656,6 +669,60 @@ mod test_js_deadcode {
         assert_eq!(
             clean("if (x) { console.log('maybe'); }"),
             "if (x) { console.log('maybe'); }"
+        );
+    }
+
+    #[test]
+    fn test_simplify_switch_case_match() {
+        assert_eq!(
+            clean(
+                "switch (2) { case 1: console.log('no'); break; case 2: console.log('yes'); break; default: console.log('d'); }"
+            ),
+            "console.log('yes');"
+        );
+    }
+
+    #[test]
+    fn test_simplify_switch_case_match_with_early_break() {
+        assert_eq!(
+            clean(
+                "switch (2) {
+                        case 1:
+                            console.log('no');
+                            break;
+                        case 2:
+                            console.log('yes');
+                            break;
+                            console.log('no');
+                        default:
+                            console.log('d');
+                    }"
+            ),
+            "console.log('yes');"
+        );
+    }
+
+    #[test]
+    fn test_simplify_switch_case_default() {
+        assert_eq!(
+            clean("switch (3) { case 1: a(); break; case 2: b(); break; default: c(); }"),
+            "c();"
+        );
+    }
+
+    #[test]
+    fn test_keep_switch_without_break_fallthrough() {
+        assert_eq!(
+            clean("switch (1) { case 1: a(); case 2: b(); break; default: c(); }"),
+            "switch (1) { case 1: a(); case 2: b(); break; default: c(); }"
+        );
+    }
+
+    #[test]
+    fn test_keep_switch_with_non_literal_case() {
+        assert_eq!(
+            clean("switch (1) { case x: a(); break; default: b(); }"),
+            "switch (1) { case x: a(); break; default: b(); }"
         );
     }
 

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -15,6 +15,7 @@ pub mod regex;
 pub mod specials;
 pub mod strategy;
 pub mod string;
+pub mod r#switch;
 mod tests;
 pub mod r#typeof;
 mod utils;
@@ -70,7 +71,7 @@ pub enum JavaScript {
     Null,
     // Byte is a special type that does not live long, it's used to store the result of `atob` and
     // `btoa` calls, and it's converted to string when it's used in a string context, but it gets
-    // most of the type converted into a string
+    // most of the time converted into a string
     Bytes(Vec<u8>),
     Object {
         map: HashMap<String, JavaScript>,

--- a/core/src/js/specials.rs
+++ b/core/src/js/specials.rs
@@ -47,6 +47,16 @@ impl<'a> RuleMut<'a> for ParseSpecials {
                     return Ok(());
                 }
             }
+            "null" => {
+                trace!("ParseSpecials (L): null");
+                node.reduce(Null);
+                return Ok(());
+            }
+            "NaN" => {
+                trace!("ParseSpecials (L): NaN");
+                node.reduce(NaN);
+                return Ok(());
+            }
             _ => {}
         }
 

--- a/core/src/js/switch.rs
+++ b/core/src/js/switch.rs
@@ -1,0 +1,140 @@
+use crate::tree::Node;
+
+#[derive(Clone, Debug, PartialEq)]
+enum SwitchLiteral {
+    Bool(bool),
+    Num(f64),
+    Str(String),
+    Null,
+    Undefined,
+}
+
+fn parse_simple_string_literal(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 2 {
+        return None;
+    }
+
+    let quote = *bytes.first()?;
+    if (quote != b'\'' && quote != b'"') || *bytes.last()? != quote {
+        return None;
+    }
+
+    let inner = &text[1..text.len() - 1];
+    if inner.contains('\\') {
+        return None;
+    }
+
+    Some(inner.to_string())
+}
+
+fn parse_literal(node: &Node<()>) -> Option<SwitchLiteral> {
+    if node.kind() == "parenthesized_expression" {
+        for child in node.iter() {
+            if child.kind() != "(" && child.kind() != ")" {
+                return parse_literal(&child);
+            }
+        }
+        return None;
+    }
+
+    let text = node.text().ok()?.trim();
+    match node.kind() {
+        "true" => Some(SwitchLiteral::Bool(true)),
+        "false" => Some(SwitchLiteral::Bool(false)),
+        "null" => Some(SwitchLiteral::Null),
+        "undefined" => Some(SwitchLiteral::Undefined),
+        "string" => parse_simple_string_literal(text).map(SwitchLiteral::Str),
+        "number" => text.parse::<f64>().ok().map(SwitchLiteral::Num),
+        _ => None,
+    }
+}
+
+fn extract_selected_clause_text(clause: &Node<()>, is_last_clause: bool) -> Option<String> {
+    let mut parts = Vec::new();
+    let mut terminates = false;
+
+    let value_id = clause.named_child("value").map(|value| value.id());
+    for stmt in clause
+        .iter()
+        .filter(|child| !matches!(child.kind(), "case" | "default" | ":"))
+        .filter(|child| Some(child.id()) != value_id)
+    {
+        match stmt.kind() {
+            "break_statement" => {
+                terminates = true;
+                break;
+            }
+            "return_statement" | "throw_statement" => {
+                parts.push(stmt.text().ok()?.trim().to_string());
+                terminates = true;
+                break;
+            }
+            _ => parts.push(stmt.text().ok()?.trim().to_string()),
+        }
+    }
+
+    if !terminates && !is_last_clause {
+        return None;
+    }
+
+    Some(parts.join(" "))
+}
+
+pub fn simplify_switch_statement_text(node: &Node<()>) -> Option<String> {
+    if node.kind() != "switch_statement" {
+        return None;
+    }
+
+    let switch_value = parse_literal(&node.named_child("value")?)?;
+    let body = node.named_child("body")?;
+
+    let mut total_clauses = 0usize;
+    let mut selected_idx = None;
+    let mut default_idx = None;
+
+    for clause in body.iter() {
+        if !matches!(clause.kind(), "switch_case" | "switch_default") {
+            continue;
+        }
+
+        match clause.kind() {
+            "switch_case" => {
+                let case_value = parse_literal(&clause.named_child("value")?)?;
+                if selected_idx.is_none() && case_value == switch_value {
+                    selected_idx = Some(total_clauses);
+                }
+            }
+            "switch_default" => {
+                if default_idx.is_none() {
+                    default_idx = Some(total_clauses);
+                }
+            }
+            _ => {}
+        }
+
+        total_clauses += 1;
+    }
+
+    if total_clauses == 0 {
+        return Some(String::new());
+    }
+
+    let selected_idx = selected_idx.or(default_idx)?;
+    let mut clause_idx = 0usize;
+
+    for clause in body.iter() {
+        if !matches!(clause.kind(), "switch_case" | "switch_default") {
+            continue;
+        }
+
+        if clause_idx == selected_idx {
+            let is_last_clause = clause_idx + 1 == total_clauses;
+            return extract_selected_clause_text(&clause, is_last_clause);
+        }
+
+        clause_idx += 1;
+    }
+
+    None
+}

--- a/core/src/js/switch.rs
+++ b/core/src/js/switch.rs
@@ -50,10 +50,7 @@ fn parse_literal(node: &Node<()>) -> Option<SwitchLiteral> {
     }
 }
 
-fn extract_selected_clause_text(clause: &Node<()>, is_last_clause: bool) -> Option<String> {
-    let mut parts = Vec::new();
-    let mut terminates = false;
-
+fn append_clause_statements(clause: &Node<()>, parts: &mut Vec<String>) -> Option<bool> {
     let value_id = clause.named_child("value").map(|value| value.id());
     for stmt in clause
         .iter()
@@ -61,24 +58,16 @@ fn extract_selected_clause_text(clause: &Node<()>, is_last_clause: bool) -> Opti
         .filter(|child| Some(child.id()) != value_id)
     {
         match stmt.kind() {
-            "break_statement" => {
-                terminates = true;
-                break;
-            }
+            "break_statement" => return Some(true),
             "return_statement" | "throw_statement" => {
                 parts.push(stmt.text().ok()?.trim().to_string());
-                terminates = true;
-                break;
+                return Some(true);
             }
             _ => parts.push(stmt.text().ok()?.trim().to_string()),
         }
     }
 
-    if !terminates && !is_last_clause {
-        return None;
-    }
-
-    Some(parts.join(" "))
+    Some(false)
 }
 
 pub fn simplify_switch_statement_text(node: &Node<()>) -> Option<String> {
@@ -122,6 +111,8 @@ pub fn simplify_switch_statement_text(node: &Node<()>) -> Option<String> {
 
     let selected_idx = selected_idx.or(default_idx)?;
     let mut clause_idx = 0usize;
+    let mut parts = Vec::new();
+    let mut collecting = false;
 
     for clause in body.iter() {
         if !matches!(clause.kind(), "switch_case" | "switch_default") {
@@ -129,12 +120,15 @@ pub fn simplify_switch_statement_text(node: &Node<()>) -> Option<String> {
         }
 
         if clause_idx == selected_idx {
-            let is_last_clause = clause_idx + 1 == total_clauses;
-            return extract_selected_clause_text(&clause, is_last_clause);
+            collecting = true;
+        }
+
+        if collecting && append_clause_statements(&clause, &mut parts)? {
+            return Some(parts.join(" "));
         }
 
         clause_idx += 1;
     }
 
-    None
+    Some(parts.join(" "))
 }

--- a/core/src/js/typeof.rs
+++ b/core/src/js/typeof.rs
@@ -4,6 +4,7 @@ use crate::js::JavaScript::Raw;
 use crate::js::Value::Str;
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
+use log::warn;
 
 /// Infer unary typeof calls
 ///
@@ -45,6 +46,16 @@ impl<'a> RuleMut<'a> for Typeof {
         if view.kind() != "unary_expression" {
             return Ok(());
         }
+
+        if let Ok(text) = view.text() {
+            if text == "typeof window" || text == "typeof document" || text == "typeof browser" {
+                warn!(
+                    "The script tried to detect if the environment is a browser by using '{}'.",
+                    text
+                );
+            }
+        }
+
         if let (Some(left), Some(right)) = (view.child(0), view.child(1)) {
             if left.text()? == "typeof" {
                 if let Some(r) = right.data() {


### PR DESCRIPTION
It also handles case with missing breaks like this:
```js
switch (2) {
    case 1:
        console.log('no');
        break;
    case 2:
        console.log('yes');
    default:
        console.log('yes');
    case 3:
        console.log('yes');
}
```
```js
switch (2) {
    case 1:
        console.log('no');
        break;
    case 2:
        console.log('yes');
    case 3:
        console.log('yes');
        break
    default:
        console.log('no');
}
```