### PR TITLE
Implemented all builtin methods on number literals

### DIFF
--- a/core/src/js/integer.rs
+++ b/core/src/js/integer.rs
@@ -298,10 +298,13 @@ fn digit_value(c: char, radix: u32) -> Option<u32> {
 /// Centralized dispatcher for number literal builtins.
 ///
 /// This includes :
-/// - `str.valueOf(n)` why not?
+/// - `str.valueOf(n)` what is the purpose of this??
 type NumberBuiltinHandler = fn(f64, &[JavaScript]) -> Option<JavaScript>;
 
-const NUMBER_BUILTINS: &[(&str, NumberBuiltinHandler)] = &[("valueOf", number_builtin_value_of)];
+const NUMBER_BUILTINS: &[(&str, NumberBuiltinHandler)] = &[
+    ("valueOf", |value, _args| Some(Raw(Num(value)))),
+    ("toPrecision", number_builtin_to_precision),
+];
 
 #[derive(Default)]
 pub struct NumberBuiltins;
@@ -371,8 +374,76 @@ fn dispatch_number_builtin(method: &str, input: f64, args: &[JavaScript]) -> Opt
         .flatten()
 }
 
-fn number_builtin_value_of(input: f64, args: &[JavaScript]) -> Option<JavaScript> {
-    Some(Raw(Num(input)))
+/// See [ECMA262 21.1.3.5](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.toprecision)
+pub fn number_builtin_to_precision(input: f64, args: &[JavaScript]) -> Option<JavaScript> {
+    if args.is_empty() {
+        return Some(Raw(Str(Raw(Num(input)).to_string())));
+    }
+
+    let precision = match args[0].as_js_num() {
+        Raw(Num(n)) => n as isize,
+        _ => {
+            warn!("BuiltinToPrecision: received invalid arg, skipping...");
+            return None;
+        }
+    };
+
+    if input.is_infinite() {
+        return Some(Raw(Str(if input.is_sign_negative() {
+            "-Infinity".to_string()
+        } else {
+            "Infinity".to_string()
+        })));
+    }
+
+    if precision < 1 || precision > 100 {
+        warn!("BuiltinToPrecision: precision out of range [1, 100], skipping...");
+        return None;
+    }
+
+    let p = precision as usize;
+
+    if input == 0.0 {
+        if p == 1 {
+            return Some(Raw(Str("0".to_string())));
+        }
+        return Some(Raw(Str(format!("0.{}", "0".repeat(p - 1)))));
+    }
+
+    let sign = if input.is_sign_negative() { "-" } else { "" };
+    let abs = input.abs();
+
+    let exp_repr = format!("{:.*e}", p - 1, abs);
+    let (mantissa, exp_part) = exp_repr.split_once('e')?;
+    let exponent: isize = exp_part.parse().ok()?;
+
+    let digits: String = mantissa.chars().filter(|c| *c != '.').collect();
+
+    let result = if exponent < -6 || exponent >= p as isize {
+        let exp_suffix = if exponent >= 0 {
+            format!("e+{}", exponent)
+        } else {
+            format!("e{}", exponent)
+        };
+
+        if p == 1 {
+            format!("{sign}{}{}", &digits[..1], exp_suffix)
+        } else {
+            format!("{sign}{}.{}{}", &digits[..1], &digits[1..p], exp_suffix)
+        }
+    } else if exponent >= 0 {
+        let int_len = (exponent + 1) as usize;
+        if int_len >= p {
+            format!("{sign}{digits}")
+        } else {
+            format!("{sign}{}.{}", &digits[..int_len], &digits[int_len..p])
+        }
+    } else {
+        let zeros = "0".repeat((-exponent - 1) as usize);
+        format!("{sign}0.{}{}", zeros, digits)
+    };
+
+    Some(Raw(Str(result)))
 }
 
 /// Infers unary `-` and `+` expressions applied to known values
@@ -1240,6 +1311,7 @@ mod tests_js_integer {
     use super::*;
     use crate::js::array::ParseArray;
     use crate::js::build_javascript_tree;
+    use crate::js::forward::Forward;
     use crate::js::linter::Linter;
     use crate::js::string::ParseString;
 
@@ -1251,6 +1323,7 @@ mod tests_js_integer {
             ParseArray::default(),
             NumberBuiltins::default(),
             PosNeg::default(),
+            Forward::default(),
             AddInt::default(),
             Substract::default(),
             IncrDecr::default(),
@@ -1440,5 +1513,85 @@ mod tests_js_integer {
     fn test_builtin_value_of() {
         assert_eq!(deobfuscate("var x = 12.34.valueOf();"), "var x = 12.34;");
         assert_eq!(deobfuscate("var x = 12.34['valueOf']();"), "var x = 12.34;");
+    }
+
+    #[test]
+    fn test_builtin_to_precision() {
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toPrecision();"),
+            "var x = '12.3456';"
+        );
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toPrecision(1);"),
+            "var x = '1e+1';"
+        );
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toPrecision(2);"),
+            "var x = '12';"
+        );
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toPrecision(4);"),
+            "var x = '12.35';"
+        );
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toPrecision(6);"),
+            "var x = '12.3456';"
+        );
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toPrecision(8);"),
+            "var x = '12.345600';"
+        );
+        assert_eq!(deobfuscate("var x = (0).toPrecision(1);"), "var x = '0';");
+        assert_eq!(
+            deobfuscate("var x = (0).toPrecision(4);"),
+            "var x = '0.000';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-12.3456).toPrecision(4);"),
+            "var x = '-12.35';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-12.3456).toPrecision(1);"),
+            "var x = '-1e+1';"
+        );
+        assert_eq!(
+            // output '0.0000000' instead of '0.0000012'
+            deobfuscate("var x = (0.000001234).toPrecision(2);"),
+            "var x = '0.0000012';"
+        );
+        assert_eq!(
+            // output '0e-7' instead of '1e-7'
+            deobfuscate("var x = (0.0000001).toPrecision(1);"),
+            "var x = '1e-7';"
+        );
+        assert_eq!(
+            // output '0.000000' instead of '0.000001'
+            deobfuscate("var x = (0.000001).toPrecision(1);"),
+            "var x = '0.000001';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (123456789).toPrecision(4);"),
+            "var x = '1.235e+8';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (9.9999).toPrecision(1);"),
+            "var x = '1e+1';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (Infinity).toPrecision(3);"),
+            "var x = 'Infinity';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-Infinity).toPrecision(3);"),
+            "var x = '-Infinity';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toPrecision(0);"),
+            "var x = 1.5.toPrecision(0);"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toPrecision(101);"),
+            "var x = 1.5.toPrecision(101);"
+        );
     }
 }

--- a/core/src/js/integer.rs
+++ b/core/src/js/integer.rs
@@ -304,6 +304,7 @@ type NumberBuiltinHandler = fn(f64, &[JavaScript]) -> Option<JavaScript>;
 const NUMBER_BUILTINS: &[(&str, NumberBuiltinHandler)] = &[
     ("valueOf", |value, _args| Some(Raw(Num(value)))),
     ("toPrecision", number_builtin_to_precision),
+    ("toFixed", number_builtin_to_fixed),
 ];
 
 #[derive(Default)]
@@ -444,6 +445,46 @@ pub fn number_builtin_to_precision(input: f64, args: &[JavaScript]) -> Option<Ja
     };
 
     Some(Raw(Str(result)))
+}
+
+/// See [ECMA262 21.1.3.3](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tofixed)
+pub fn number_builtin_to_fixed(input: f64, args: &[JavaScript]) -> Option<JavaScript> {
+    let fraction_count = match args.first() {
+        None => 0isize,
+        Some(arg) => match arg.as_js_num() {
+            Raw(Num(n)) => n as isize,
+            _ => 0,
+        },
+    };
+
+    if !(0..=100).contains(&fraction_count) {
+        warn!("BuiltinToFixed: fractionDigits out of range [0, 100], skipping...");
+        return None;
+    }
+
+    if input.is_infinite() {
+        return Some(Raw(Str(if input.is_sign_negative() {
+            "-Infinity".to_string()
+        } else {
+            "Infinity".to_string()
+        })));
+    }
+
+    let f = fraction_count as usize;
+    let sign = if input.is_sign_negative() && input != 0.0 {
+        "-"
+    } else {
+        ""
+    };
+    let abs = input.abs();
+
+    if abs >= 1e21 {
+        return Some(Raw(Str(format!("{sign}{}", Raw(Num(abs)).to_string()))));
+    }
+
+    let digit_string = format!("{:.prec$}", abs, prec = f);
+
+    Some(Raw(Str(format!("{sign}{digit_string}"))))
 }
 
 /// Infers unary `-` and `+` expressions applied to known values
@@ -1592,6 +1633,69 @@ mod tests_js_integer {
         assert_eq!(
             deobfuscate("var x = (1.5).toPrecision(101);"),
             "var x = 1.5.toPrecision(101);"
+        );
+    }
+
+    #[test]
+    fn test_builtin_to_fixed() {
+        assert_eq!(deobfuscate("var x = 12.3456.toFixed();"), "var x = '12';");
+        assert_eq!(deobfuscate("var x = (1.005).toFixed();"), "var x = '1';");
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toFixed(2);"),
+            "var x = '12.35';"
+        );
+        assert_eq!(
+            deobfuscate("var x = 12.3456.toFixed(4);"),
+            "var x = '12.3456';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toFixed(4);"),
+            "var x = '1.5000';"
+        );
+        assert_eq!(deobfuscate("var x = (0).toFixed(3);"), "var x = '0.000';");
+        assert_eq!(deobfuscate("var x = (1.9).toFixed(0);"), "var x = '2';");
+        assert_eq!(deobfuscate("var x = (1.1).toFixed(0);"), "var x = '1';");
+        assert_eq!(deobfuscate("var x = (-1.5).toFixed(0);"), "var x = '-2';");
+        assert_eq!(
+            deobfuscate("var x = (-12.3456).toFixed(2);"),
+            "var x = '-12.35';"
+        );
+        assert_eq!(deobfuscate("var x = (0).toFixed(0);"), "var x = '0';");
+        assert_eq!(
+            deobfuscate("var x = (-0).toFixed(2);"),
+            "var x = '0.00';" // -0 has no sign in output per spec step 9
+        );
+        assert_eq!(
+            deobfuscate("var x = (0.000001).toFixed(8);"),
+            "var x = '0.00000100';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1e15).toFixed(0);"),
+            "var x = '1000000000000000';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1e21).toFixed(2);"),
+            "var x = '1e+21';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5e21).toFixed(0);"),
+            "var x = '1.5e+21';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (Infinity).toFixed(2);"),
+            "var x = 'Infinity';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-Infinity).toFixed(2);"),
+            "var x = '-Infinity';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toFixed(-1);"),
+            "var x = 1.5.toFixed(-1);"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toFixed(101);"),
+            "var x = 1.5.toFixed(101);"
         );
     }
 }

--- a/core/src/js/integer.rs
+++ b/core/src/js/integer.rs
@@ -2,13 +2,13 @@ use crate::error::MinusOneResult;
 use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::*;
-use std::ops::{Shl, Shr};
-
 use crate::js::utils::{get_positional_arguments, method_name};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::{error, trace, warn};
 use num::ToPrimitive;
+use std::ops::{Shl, Shr};
+use std::string::ToString;
 
 /// Parses JavaScript numeric literals (decimal, hex, octal, binary) into `Raw(Num(_))`.
 ///
@@ -298,13 +298,17 @@ fn digit_value(c: char, radix: u32) -> Option<u32> {
 /// Centralized dispatcher for number literal builtins.
 ///
 /// This includes :
-/// - `str.valueOf(n)` what is the purpose of this??
+/// - `num.valueOf()` what is the purpose of this??
+/// - `num.toPrecision(x)`
+/// - `num.toFixed(x)`
+/// - `num.toExponential(x)`
 type NumberBuiltinHandler = fn(f64, &[JavaScript]) -> Option<JavaScript>;
 
 const NUMBER_BUILTINS: &[(&str, NumberBuiltinHandler)] = &[
     ("valueOf", |value, _args| Some(Raw(Num(value)))),
     ("toPrecision", number_builtin_to_precision),
     ("toFixed", number_builtin_to_fixed),
+    ("toExponential", number_builtin_to_exponential),
 ];
 
 #[derive(Default)]
@@ -450,14 +454,14 @@ pub fn number_builtin_to_precision(input: f64, args: &[JavaScript]) -> Option<Ja
 /// See [ECMA262 21.1.3.3](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tofixed)
 pub fn number_builtin_to_fixed(input: f64, args: &[JavaScript]) -> Option<JavaScript> {
     let fraction_count = match args.first() {
-        None => 0isize,
+        None => 0,
         Some(arg) => match arg.as_js_num() {
-            Raw(Num(n)) => n as isize,
+            Raw(Num(n)) => n as i64,
             _ => 0,
         },
     };
 
-    if !(0..=100).contains(&fraction_count) {
+    if fraction_count < 0 || fraction_count > 100 {
         warn!("BuiltinToFixed: fractionDigits out of range [0, 100], skipping...");
         return None;
     }
@@ -485,6 +489,89 @@ pub fn number_builtin_to_fixed(input: f64, args: &[JavaScript]) -> Option<JavaSc
     let digit_string = format!("{:.prec$}", abs, prec = f);
 
     Some(Raw(Str(format!("{sign}{digit_string}"))))
+}
+
+/// See [ECMA262 21.1.3.2](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.toexponential)
+pub fn number_builtin_to_exponential(input: f64, args: &[JavaScript]) -> Option<JavaScript> {
+    let fraction_digits_undefined =
+        args.is_empty() || matches!(args.first(), Some(Undefined) | Some(Null));
+
+    let fraction_count = match args.first() {
+        None => 0,
+        Some(arg) => match arg.as_js_num() {
+            Raw(Num(n)) => n as i64,
+            _ => 0,
+        },
+    };
+
+    if input.is_infinite() {
+        return Some(Raw(Str(if input.is_sign_negative() {
+            "-Infinity".to_string()
+        } else {
+            "Infinity".to_string()
+        })));
+    }
+
+    if !fraction_digits_undefined && (fraction_count < 0 || fraction_count > 100) {
+        warn!("BuiltinToExponential: fractionDigits out of range [0, 100], skipping...");
+        return None;
+    }
+
+    let sign = if input.is_sign_negative() && input != 0.0 {
+        "-"
+    } else {
+        ""
+    };
+    let abs = input.abs();
+
+    if abs == 0.0 {
+        let f = if fraction_digits_undefined {
+            0
+        } else {
+            fraction_count as usize
+        };
+        let significand = if f == 0 {
+            "0".to_string()
+        } else {
+            format!("0.{}", "0".repeat(f))
+        };
+        return Some(Raw(Str(format!("{sign}{significand}e+0"))));
+    }
+
+    let (significand, exponent) = if fraction_digits_undefined {
+        let repr = format!("{:e}", abs);
+        let (mantissa, exp_str) = repr.split_once('e')?;
+        let exponent: isize = exp_str.parse().ok()?;
+        let digits: String = mantissa.chars().filter(|c| *c != '.').collect();
+        let digits = digits.trim_end_matches('0');
+        let f = digits.len() - 1;
+        let sig = if f == 0 {
+            digits.to_string()
+        } else {
+            format!("{}.{}", &digits[..1], &digits[1..])
+        };
+        (sig, exponent)
+    } else {
+        let f = fraction_count as usize;
+        let repr = format!("{:.*e}", f, abs);
+        let (mantissa, exp_str) = repr.split_once('e')?;
+        let exponent: isize = exp_str.parse().ok()?;
+        let digits: String = mantissa.chars().filter(|c| *c != '.').collect();
+        let sig = if f == 0 {
+            digits[..1].to_string()
+        } else {
+            format!("{}.{}", &digits[..1], &digits[1..=f])
+        };
+        (sig, exponent)
+    };
+
+    let exp_suffix = if exponent >= 0 {
+        format!("e+{}", exponent)
+    } else {
+        format!("e{}", exponent)
+    };
+
+    Some(Raw(Str(format!("{sign}{significand}{exp_suffix}"))))
 }
 
 /// Infers unary `-` and `+` expressions applied to known values
@@ -1696,6 +1783,82 @@ mod tests_js_integer {
         assert_eq!(
             deobfuscate("var x = (1.5).toFixed(101);"),
             "var x = 1.5.toFixed(101);"
+        );
+    }
+
+    #[test]
+    fn test_builtin_to_exponential() {
+        assert_eq!(
+            deobfuscate("var x = (12345.6789).toExponential();"),
+            "var x = '1.23456789e+4';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (100).toExponential();"),
+            "var x = '1e+2';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toExponential();"),
+            "var x = '1.5e+0';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (12345.6789).toExponential(2);"),
+            "var x = '1.23e+4';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (12345.6789).toExponential(6);"),
+            "var x = '1.234568e+4';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (12345.6789).toExponential(0);"),
+            "var x = '1e+4';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toExponential(4);"),
+            "var x = '1.5000e+0';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (0).toExponential();"),
+            "var x = '0e+0';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (0).toExponential(3);"),
+            "var x = '0.000e+0';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-12345.6789).toExponential(2);"),
+            "var x = '-1.23e+4';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-0.00123).toExponential(2);"),
+            "var x = '-1.23e-3';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (0.00123).toExponential(2);"),
+            "var x = '1.23e-3';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (0.0000001).toExponential(1);"),
+            "var x = '1.0e-7';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (5).toExponential(3);"),
+            "var x = '5.000e+0';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (Infinity).toExponential();"),
+            "var x = 'Infinity';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (-Infinity).toExponential(2);"),
+            "var x = '-Infinity';"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toExponential(-1);"),
+            "var x = 1.5.toExponential(-1);"
+        );
+        assert_eq!(
+            deobfuscate("var x = (1.5).toExponential(101);"),
+            "var x = 1.5.toExponential(101);"
         );
     }
 }

--- a/core/src/js/integer.rs
+++ b/core/src/js/integer.rs
@@ -4,6 +4,7 @@ use crate::js::JavaScript::*;
 use crate::js::Value::*;
 use std::ops::{Shl, Shr};
 
+use crate::js::utils::{get_positional_arguments, method_name};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::{error, trace, warn};
@@ -292,6 +293,86 @@ fn to_int32(value: &JavaScript) -> i32 {
 fn digit_value(c: char, radix: u32) -> Option<u32> {
     let d = c.to_digit(36)?;
     if d < radix { Some(d) } else { None }
+}
+
+/// Centralized dispatcher for number literal builtins.
+///
+/// This includes :
+/// - `str.valueOf(n)` why not?
+type NumberBuiltinHandler = fn(f64, &[JavaScript]) -> Option<JavaScript>;
+
+const NUMBER_BUILTINS: &[(&str, NumberBuiltinHandler)] = &[("valueOf", number_builtin_value_of)];
+
+#[derive(Default)]
+pub struct NumberBuiltins;
+
+impl<'a> RuleMut<'a> for NumberBuiltins {
+    type Language = JavaScript;
+
+    fn enter(
+        &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        let view = node.view();
+        if view.kind() != "call_expression" {
+            return Ok(());
+        }
+
+        let Some(callee) = view.named_child("function").or_else(|| view.child(0)) else {
+            return Ok(());
+        };
+        let Some(method) = method_name(&callee) else {
+            return Ok(());
+        };
+
+        let Some(object) = callee.child(0).or_else(|| callee.named_child("object")) else {
+            return Ok(());
+        };
+        let Some(Raw(Num(input))) = object.data() else {
+            return Ok(());
+        };
+
+        let args = view.named_child("arguments");
+        let positional_args = get_positional_arguments(args);
+        let mut arg_values = Vec::with_capacity(positional_args.len());
+        for arg in positional_args {
+            let Some(value) = arg.data().cloned() else {
+                return Ok(());
+            };
+            arg_values.push(value);
+        }
+
+        let Some(result) = dispatch_number_builtin(&method, *input, &arg_values) else {
+            return Ok(());
+        };
+
+        trace!(
+            "NumberBuiltins: reducing '{}'.{}(...) to {}",
+            input, method, result
+        );
+        node.reduce(result);
+        Ok(())
+    }
+}
+
+fn dispatch_number_builtin(method: &str, input: f64, args: &[JavaScript]) -> Option<JavaScript> {
+    NUMBER_BUILTINS
+        .iter()
+        .find_map(|(name, handler)| (*name == method).then(|| handler(input, args)))
+        .flatten()
+}
+
+fn number_builtin_value_of(input: f64, args: &[JavaScript]) -> Option<JavaScript> {
+    Some(Raw(Num(input)))
 }
 
 /// Infers unary `-` and `+` expressions applied to known values
@@ -1168,6 +1249,7 @@ mod tests_js_integer {
             ParseInt::default(),
             ParseString::default(),
             ParseArray::default(),
+            NumberBuiltins::default(),
             PosNeg::default(),
             AddInt::default(),
             Substract::default(),
@@ -1339,11 +1421,11 @@ mod tests_js_integer {
 
     #[test]
     fn test_incr_decr() {
-        assert_eq!(deobfuscate("var y = ++5;"), "var y = 6;");
-        assert_eq!(deobfuscate("var y = --5;"), "var y = 4;");
-        assert_eq!(deobfuscate("var y = 5++;"), "var y = 6;");
-        assert_eq!(deobfuscate("var y = 5--;"), "var y = 4;");
-        assert_eq!(deobfuscate("var y = ++5 + 1;"), "var y = 7;");
+        assert_eq!(deobfuscate("var x = ++5;"), "var x = 6;");
+        assert_eq!(deobfuscate("var x = --5;"), "var x = 4;");
+        assert_eq!(deobfuscate("var x = 5++;"), "var x = 6;");
+        assert_eq!(deobfuscate("var x = 5--;"), "var x = 4;");
+        assert_eq!(deobfuscate("var x = ++5 + 1;"), "var x = 7;");
         assert_eq!(
             deobfuscate("for (var i = 0; i < 10; i++) {}"),
             "for (var i = 0; i < 10; i++) {}"
@@ -1352,5 +1434,11 @@ mod tests_js_integer {
             deobfuscate("for (var i = 0; i < 10; --i) {}"),
             "for (var i = 0; i < 10; --i) {}"
         );
+    }
+
+    #[test]
+    fn test_builtin_value_of() {
+        assert_eq!(deobfuscate("var x = 12.34.valueOf();"), "var x = 12.34;");
+        assert_eq!(deobfuscate("var x = 12.34['valueOf']();"), "var x = 12.34;");
     }
 }

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -160,6 +160,7 @@ impl_javascript_ruleset!(
     AddBool,              // Infer boolean addition operations
     CombineArrays,        // Infer + operations on two arrays
     StringBuiltins,       // Shared dispatcher for string literal builtins (.at, etc.)
+    NumberBuiltins,       // Shared dispatcher for string literal builtins (.toPrecision, etc.)
     BracketCharAt, // Infer charAt calls on string literals and reduces them to single-character string literals using arrays indexes
     CharCodeAt, // Infer charCodeAt calls on string literals and reduces them to integer literals using arrays indexes
     FromCharCode, // Infer String.fromCharCode static calls on deterministic literal arguments


### PR DESCRIPTION
This includes :
- `num.valueOf()`
- `num.toPrecision(x)` #172
- `num.toFixed(x)`
- `num.toExponential(x)`

Only `.toLocaleString(lang)` is not implemented