### PR TITLE
More array fns

### DIFF
--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -592,10 +592,6 @@ fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<Ja
     if input.is_empty() {
         Some(Undefined)
     } else {
-        // todo the input must be mutable or we need to find a way to alter the var manager
-        warn!(
-            "The pop() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-        );
         Some(input[input.len() - 1].clone())
     }
 }
@@ -605,33 +601,15 @@ fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<Ja
 /// returns the new length<br>
 /// _(mutates array)_
 fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
-    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    if args.is_empty() {
-        Some(Raw(Num((input.len()) as f64)))
-    } else {
-        warn!(
-            "The push() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-        );
-        Some(Raw(Num((input.len() + args.len()) as f64)))
-    }
+    Some(Raw(Num((input.len() + args.len()) as f64)))
 }
 
 /// # `.reverse()`
 /// Reverse othe order of the array and also return it<br>
 /// _(mutates array)_
 fn array_builtin_reverse(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
-    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    if input.is_empty() {
-        Some(Array(vec![]))
-    } else {
-        let new_array: Vec<JavaScript> = input.iter().rev().cloned().collect();
-        if Array(new_array.clone()) != Array(input.clone()) {
-            warn!(
-                "The reverse() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-            );
-        }
-        Some(Array(new_array))
-    }
+    let new_array = input.iter().rev().cloned().collect();
+    Some(Array(new_array))
 }
 
 /// # `.toReversed()`
@@ -645,13 +623,9 @@ fn array_builtin_to_reversed(input: &Vec<JavaScript>, _args: &[JavaScript]) -> O
 /// Removes and returns first element<br>
 /// _(mutates array)_
 fn array_builtin_shift(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
-    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
     if input.is_empty() {
         Some(Undefined)
     } else {
-        warn!(
-            "The shift() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-        );
         Some(input[0].clone())
     }
 }
@@ -698,34 +672,19 @@ fn array_builtin_slice(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<J
 /// Sort the array (`to_string` based ??)<br>
 /// _(mutates array)_
 fn array_builtin_sort(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
-    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    // todo: in the future handle arrow fn as sort arg
-    if input.is_empty() {
-        Some(Array(vec![]))
-    } else {
-        if args.first().is_some() {
-            warn!(
-                "The sort() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-            );
-            warn!("The sort() builtin does not handle custom comparator functions. Skipping...");
-            return None;
-        }
-        let mut new_array = input.clone();
-        new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
-        if Array(new_array.clone()) != Array(input.clone()) {
-            warn!(
-                "The sort() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-            );
-        }
-        Some(Array(new_array))
+    if let Some(Function { .. }) = args.first() {
+        warn!("The sort() builtin does not handle custom comparator functions. Skipping...");
+        return None;
     }
+    let mut new_array = input.clone();
+    new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
+    Some(Array(new_array))
 }
 
 /// # `.toSorted([customSortFn])`
 /// `.sort([customSortFn])` but create a copy so it does *not mutate* the original array
 fn array_builtin_to_sorted(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
-    // todo: in the future handle arrow fn as sort arg
-    if args.first().is_some() {
+    if let Some(Function { .. }) = args.first() {
         warn!("The sort() builtin does not handle custom comparator functions. Skipping...");
         return None;
     }
@@ -739,15 +698,7 @@ fn array_builtin_to_sorted(input: &Vec<JavaScript>, args: &[JavaScript]) -> Opti
 /// returns new length<br>
 /// _(mutates array)_
 fn array_builtin_unshift(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
-    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    if args.is_empty() {
-        Some(Raw(Num((input.len()) as f64)))
-    } else {
-        warn!(
-            "The unshift() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
-        );
-        Some(Raw(Num((args.len() + input.len()) as f64)))
-    }
+    Some(Raw(Num((args.len() + input.len()) as f64)))
 }
 
 /// Infers `+` on two arrays

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -75,6 +75,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("toString", |arr, _| {
         Some(Raw(Str(flatten_array(arr, None))))
     }),
+    ("unshift", array_builtin_unshift),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -655,6 +656,15 @@ fn array_builtin_to_sorted(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Opt
     let mut new_array = input.clone();
     new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
     Some(Array(new_array))
+}
+
+/// # `.unshift(thing1, ..., thingX)`
+/// Adds elements to start<br>
+/// returns new length<br>
+/// _(mutates array)_
+fn array_builtin_unshift(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    Some(Raw(Num((args.len() + input.len()) as f64)))
 }
 
 /// Infers `+` on two arrays
@@ -1493,5 +1503,19 @@ mod tests_js_array {
             deobfuscate("var x = [9, 10, 11].toSorted()"),
             "var x = [10, 11, 9]"
         ); // to_string moment...
+    }
+
+    #[test]
+    fn test_builtin_unshift() {
+        assert_eq!(deobfuscate("var x = [0,1,2,3].unshift()"), "var x = 4");
+        assert_eq!(deobfuscate("var x = [0,1,2,3].unshift(4)"), "var x = 5");
+        assert_eq!(
+            deobfuscate("var x = [0,1,2,3].unshift(undefined)"),
+            "var x = 5"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0,1,2,3].unshift(4,5,6,7,8,9)"),
+            "var x = 10"
+        );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -4,7 +4,7 @@ use crate::js::JavaScript::*;
 use crate::js::Value::Bool;
 use crate::js::Value::{Num, Str};
 use crate::js::b64::js_bytes_to_string;
-use crate::js::utils::{get_positional_arguments, method_name};
+use crate::js::utils::{get_positional_arguments, js_index_from_optional_arg, method_name};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::{trace, warn};
@@ -46,6 +46,97 @@ impl<'a> RuleMut<'a> for ParseArray {
 
         Ok(())
     }
+}
+
+/// Centralized dispatcher for array literal builtins.
+type ArrayBuiltinHandler = fn(&Vec<JavaScript>, &[JavaScript]) -> Option<JavaScript>;
+
+const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[("at", array_builtin_at)];
+
+#[derive(Default)]
+pub struct ArrayBuiltins;
+
+impl<'a> RuleMut<'a> for ArrayBuiltins {
+    type Language = JavaScript;
+
+    fn enter(
+        &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        let view = node.view();
+        if view.kind() != "call_expression" {
+            return Ok(());
+        }
+
+        let Some(callee) = view.named_child("function").or_else(|| view.child(0)) else {
+            return Ok(());
+        };
+        let Some(method) = method_name(&callee) else {
+            return Ok(());
+        };
+
+        let Some(object) = callee.child(0).or_else(|| callee.named_child("object")) else {
+            return Ok(());
+        };
+        let Some(Array(input)) = object.data() else {
+            return Ok(());
+        };
+
+        let args = view.named_child("arguments");
+        let positional_args = get_positional_arguments(args);
+        let mut arg_values = Vec::with_capacity(positional_args.len());
+        for arg in positional_args {
+            let Some(value) = arg.data().cloned() else {
+                return Ok(());
+            };
+            arg_values.push(value);
+        }
+
+        let Some(result) = dispatch_array_builtin(&method, input, &arg_values) else {
+            return Ok(());
+        };
+
+        trace!(
+            "ArrayBuiltins: reducing '{}'.{}(...) to {}",
+            Array(input.clone()),
+            method,
+            result
+        );
+        node.reduce(result);
+        Ok(())
+    }
+}
+
+fn dispatch_array_builtin(
+    method: &str,
+    input: &Vec<JavaScript>,
+    args: &[JavaScript],
+) -> Option<JavaScript> {
+    ARRAY_BUILTINS
+        .iter()
+        .find_map(|(name, handler)| (*name == method).then(|| handler(input, args)))
+        .flatten()
+}
+
+fn array_builtin_at(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let index = js_index_from_optional_arg(args.first());
+    let len = input.len() as i64;
+    let normalized = if index >= 0 { index } else { len + index };
+
+    if normalized < 0 || normalized >= len {
+        return Some(Undefined);
+    }
+
+    Some(input[normalized as usize].clone())
 }
 
 /// Infers `+` on two arrays

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -70,6 +70,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("slice", array_builtin_slice),
     ("sort", array_builtin_sort),
     ("toReversed", array_builtin_to_reversed),
+    ("toSorted", array_builtin_to_sorted),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -637,6 +638,16 @@ fn array_builtin_slice(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<J
 /// _(mutates array)_
 fn array_builtin_sort(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    // todo: in the future handle arrow fn as sort arg
+    let mut new_array = input.clone();
+    new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
+    Some(Array(new_array))
+}
+
+/// # `.toSorted([customSortFn])`
+/// `.sort([customSortFn])` but create a copy so it does *not mutate* the original array
+fn array_builtin_to_sorted(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    // todo: in the future handle arrow fn as sort arg
     let mut new_array = input.clone();
     new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
     Some(Array(new_array))
@@ -1462,6 +1473,20 @@ mod tests_js_array {
         assert_eq!(deobfuscate("var x = [].sort()"), "var x = []");
         assert_eq!(
             deobfuscate("var x = [9, 10, 11].sort()"),
+            "var x = [10, 11, 9]"
+        ); // to_string moment...
+    }
+
+    #[test]
+    fn test_builtin_to_sorted() {
+        assert_eq!(
+            deobfuscate("var x = [0, 8, 7, 3].toSorted()"),
+            "var x = [0, 3, 7, 8]"
+        );
+        assert_eq!(deobfuscate("var x = [0].toSorted()"), "var x = [0]");
+        assert_eq!(deobfuscate("var x = [].toSorted()"), "var x = []");
+        assert_eq!(
+            deobfuscate("var x = [9, 10, 11].toSorted()"),
             "var x = [10, 11, 9]"
         ); // to_string moment...
     }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -61,6 +61,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("flat", array_builtin_flat),
     ("includes", array_builtin_includes),
     ("indexOf", array_builtin_index_of),
+    ("join", array_builtin_join),
 ];
 
 #[derive(Default)]
@@ -336,6 +337,22 @@ fn array_builtin_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     }
 
     Some(Raw(Num(-1f64)))
+}
+
+fn array_builtin_join(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let separator = if args.is_empty() {
+        None
+    } else {
+        match args[0].clone() {
+            Undefined => None,
+            Raw(Str(s)) => Some(s.clone()),
+            Array(a) => Some(flatten_array(&a, None)),
+            any => Some(any.to_string()),
+        }
+    };
+
+    let flatten = flatten_array(input, separator);
+    Some(Raw(Str(flatten)))
 }
 
 /// Infers `+` on two arrays
@@ -755,90 +772,6 @@ fn recursive_array_number_extraction(arr: &Vec<JavaScript>) -> Option<f64> {
         Raw(Num(n)) => Some(n),
         NaN => None,
         _ => unreachable!("as_js_num should only return Raw(Num) or NaN"),
-    }
-}
-
-/// Infers join calls on arrays
-///
-/// # Example
-/// ```
-/// use minusone::js::build_javascript_tree;
-/// use minusone::js::string::{ParseString, ToString};
-/// use minusone::js::integer::ParseInt;
-/// use minusone::js::array::{ParseArray, ArrayJoin};
-/// use minusone::js::linter::Linter;
-///
-/// let mut tree = build_javascript_tree("var x = ['a', 'b'].join();").unwrap();
-/// tree.apply_mut(&mut (
-///     ParseString::default(), ParseInt::default(), ParseArray::default(), ToString::default(), ArrayJoin::default()
-/// )).unwrap();
-///
-/// let mut linter = Linter::default();
-/// tree.apply(&mut linter).unwrap();
-/// assert_eq!(linter.output, "var x = 'a,b';");
-/// ```
-#[derive(Default)]
-pub struct ArrayJoin;
-
-impl<'a> RuleMut<'a> for ArrayJoin {
-    type Language = JavaScript;
-
-    fn enter(
-        &mut self,
-        _node: &mut NodeMut<'a, Self::Language>,
-        _flow: ControlFlow,
-    ) -> MinusOneResult<()> {
-        Ok(())
-    }
-
-    fn leave(
-        &mut self,
-        node: &mut NodeMut<'a, Self::Language>,
-        _flow: ControlFlow,
-    ) -> MinusOneResult<()> {
-        let view = node.view();
-        if view.kind() != "call_expression" {
-            return Ok(());
-        }
-
-        let Some(callee) = view.named_child("function").or_else(|| view.child(0)) else {
-            return Ok(());
-        };
-
-        let Some(method) = method_name(&callee) else {
-            return Ok(());
-        };
-        if method != "join" {
-            return Ok(());
-        }
-
-        let Some(object) = callee.named_child("object") else {
-            return Ok(());
-        };
-        let Some(Array(input)) = object.data() else {
-            return Ok(());
-        };
-
-        let args = view.named_child("arguments");
-        let positional_args = get_positional_arguments(args);
-
-        let separator: Option<String> = match positional_args.first().and_then(|a| a.data()) {
-            None => None,
-            Some(Undefined) => None,
-            Some(Raw(Str(s))) => Some(s.clone()),
-            _ => return Ok(()),
-        };
-
-        let flatten = flatten_array(input, separator);
-        trace!(
-            "ArrayJoin: reducing {:?}.join({:?}) to '{}'",
-            input,
-            positional_args.first().and_then(|a| a.data()),
-            flatten
-        );
-        node.reduce(Raw(Str(flatten)));
-
-        Ok(())
     }
 }
 

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -69,6 +69,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("shift", array_builtin_shift),
     ("slice", array_builtin_slice),
     ("sort", array_builtin_sort),
+    ("toReversed", array_builtin_to_reversed),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -570,6 +571,13 @@ fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Ja
 /// _(mutates array)_
 fn array_builtin_reverse(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    let new_array = input.iter().rev().cloned().collect();
+    Some(Array(new_array))
+}
+
+/// # `.toReversed()`
+/// `.reverse()` but create a copy so it does *not mutate* the original array
+fn array_builtin_to_reversed(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     let new_array = input.iter().rev().cloned().collect();
     Some(Array(new_array))
 }
@@ -1394,6 +1402,16 @@ mod tests_js_array {
         );
         assert_eq!(deobfuscate("var x = [0].reverse()"), "var x = [0]");
         assert_eq!(deobfuscate("var x = [].reverse()"), "var x = []");
+    }
+
+    #[test]
+    fn test_builtin_to_reversed() {
+        assert_eq!(
+            deobfuscate("var x = [0,1,2,3].toReversed()"),
+            "var x = [3, 2, 1, 0]"
+        );
+        assert_eq!(deobfuscate("var x = [0].toReversed()"), "var x = [0]");
+        assert_eq!(deobfuscate("var x = [].toReversed()"), "var x = []");
     }
 
     #[test]

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -50,6 +50,32 @@ impl<'a> RuleMut<'a> for ParseArray {
 }
 
 /// Centralized dispatcher for array literal builtins.
+///
+/// This includes:
+/// - `arr.at(x)`
+/// - `arr.concat(thing1, ..., thingX)`
+/// - `arr.copyWithin(x, y[, z])`
+/// - `arr.entries()`
+/// - `arr.fill(x[, y[, z]])`
+/// - `arr.flat(x)`
+/// - `arr.includes(x)`
+/// - `arr.indexOf(x, y)`
+/// - `arr.join(s)`
+/// - `arr.lastIndexOf(x, y)`
+/// - `arr.pop()` \*
+/// - `arr.push(thing1, ..., thingX)` \*
+/// - `arr.reverse()` \*
+/// - `arr.shift()` \*
+/// - `arr.slice(x[, y])`
+/// - `arr.sort([fn])` \* \**
+/// - `arr.toReversed()`
+/// - `arr.toSorted([fn])` \**
+/// - `arr.toString()`
+/// - `arr.unshift(thing1, ..., thingX)` \*
+/// - `arr.values()`
+///
+/// \* **Warning:** This function mutates the var/let value, this is **NOT** implemented.<br>
+/// \** **Warning:** does **NOT** implement custom sorting with an arrow function
 type ArrayBuiltinHandler = fn(&Vec<JavaScript>, &[JavaScript]) -> Option<JavaScript>;
 
 const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
@@ -567,7 +593,9 @@ fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<Ja
         Some(Undefined)
     } else {
         // todo the input must be mutable or we need to find a way to alter the var manager
-        //Some(input.remove(input.len() - 1).clone())
+        warn!(
+            "The pop() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+        );
         Some(input[input.len() - 1].clone())
     }
 }
@@ -578,7 +606,14 @@ fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<Ja
 /// _(mutates array)_
 fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    Some(Raw(Num((input.len() + args.len()) as f64)))
+    if args.is_empty() {
+        Some(Raw(Num((input.len()) as f64)))
+    } else {
+        warn!(
+            "The push() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+        );
+        Some(Raw(Num((input.len() + args.len()) as f64)))
+    }
 }
 
 /// # `.reverse()`
@@ -586,8 +621,17 @@ fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Ja
 /// _(mutates array)_
 fn array_builtin_reverse(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    let new_array = input.iter().rev().cloned().collect();
-    Some(Array(new_array))
+    if input.is_empty() {
+        Some(Array(vec![]))
+    } else {
+        let new_array: Vec<JavaScript> = input.iter().rev().cloned().collect();
+        if Array(new_array.clone()) != Array(input.clone()) {
+            warn!(
+                "The reverse() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+            );
+        }
+        Some(Array(new_array))
+    }
 }
 
 /// # `.toReversed()`
@@ -605,6 +649,9 @@ fn array_builtin_shift(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<
     if input.is_empty() {
         Some(Undefined)
     } else {
+        warn!(
+            "The shift() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+        );
         Some(input[0].clone())
     }
 }
@@ -650,18 +697,38 @@ fn array_builtin_slice(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<J
 /// # `.sort([customSortFn])`
 /// Sort the array (`to_string` based ??)<br>
 /// _(mutates array)_
-fn array_builtin_sort(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+fn array_builtin_sort(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
     // todo: in the future handle arrow fn as sort arg
-    let mut new_array = input.clone();
-    new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
-    Some(Array(new_array))
+    if input.is_empty() {
+        Some(Array(vec![]))
+    } else {
+        if args.first().is_some() {
+            warn!(
+                "The sort() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+            );
+            warn!("The sort() builtin does not handle custom comparator functions. Skipping...");
+            return None;
+        }
+        let mut new_array = input.clone();
+        new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
+        if Array(new_array.clone()) != Array(input.clone()) {
+            warn!(
+                "The sort() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+            );
+        }
+        Some(Array(new_array))
+    }
 }
 
 /// # `.toSorted([customSortFn])`
 /// `.sort([customSortFn])` but create a copy so it does *not mutate* the original array
-fn array_builtin_to_sorted(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+fn array_builtin_to_sorted(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     // todo: in the future handle arrow fn as sort arg
+    if args.first().is_some() {
+        warn!("The sort() builtin does not handle custom comparator functions. Skipping...");
+        return None;
+    }
     let mut new_array = input.clone();
     new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
     Some(Array(new_array))
@@ -673,7 +740,14 @@ fn array_builtin_to_sorted(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Opt
 /// _(mutates array)_
 fn array_builtin_unshift(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
-    Some(Raw(Num((args.len() + input.len()) as f64)))
+    if args.is_empty() {
+        Some(Raw(Num((input.len()) as f64)))
+    } else {
+        warn!(
+            "The unshift() builtin is not full implemented yet due to is mutability. This means that the final output might not be correct."
+        );
+        Some(Raw(Num((args.len() + input.len()) as f64)))
+    }
 }
 
 /// Infers `+` on two arrays

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -68,6 +68,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("reverse", array_builtin_reverse),
     ("shift", array_builtin_shift),
     ("slice", array_builtin_slice),
+    ("sort", array_builtin_sort),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -621,6 +622,16 @@ fn array_builtin_slice(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<J
     let end = end.min(input.len());
     let result = input[start..end].to_vec();
     Some(Array(result))
+}
+
+/// # `.sort([customSortFn])`
+/// Sort the array (`to_string` based ??)<br>
+/// _(mutates array)_
+fn array_builtin_sort(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    let mut new_array = input.clone();
+    new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
+    Some(Array(new_array))
 }
 
 /// Infers `+` on two arrays
@@ -1421,5 +1432,19 @@ mod tests_js_array {
             deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice();"),
             "var x = [0, 1, 2, 3, 4, 5];"
         );
+    }
+
+    #[test]
+    fn test_builtin_sort() {
+        assert_eq!(
+            deobfuscate("var x = [0, 8, 7, 3].sort()"),
+            "var x = [0, 3, 7, 8]"
+        );
+        assert_eq!(deobfuscate("var x = [0].sort()"), "var x = [0]");
+        assert_eq!(deobfuscate("var x = [].sort()"), "var x = []");
+        assert_eq!(
+            deobfuscate("var x = [9, 10, 11].sort()"),
+            "var x = [10, 11, 9]"
+        ); // to_string moment...
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -3,7 +3,6 @@ use crate::js::JavaScript::*;
 use crate::js::Value::Bool;
 use crate::js::Value::{Num, Str};
 use crate::js::b64::js_bytes_to_string;
-use crate::js::comparator::strict_eq;
 use crate::js::utils::*;
 use crate::js::{IteratorKind, JavaScript};
 use crate::rule::RuleMut;
@@ -456,8 +455,8 @@ fn array_builtin_includes(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     };
 
     for value in input {
-        match strict_eq(value, &to_search, "===") {
-            Some(true) => return Some(Raw(Bool(true))),
+        match value == &to_search {
+            true => return Some(Raw(Bool(true))),
             _ => {}
         }
     }
@@ -487,8 +486,8 @@ fn array_builtin_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     };
 
     for (i, value) in input.iter().skip(start).enumerate() {
-        match strict_eq(value, &to_search, "===") {
-            Some(true) => return Some(Raw(Num((i + start) as f64))),
+        match value == &to_search {
+            true => return Some(Raw(Num((i + start) as f64))),
             _ => {}
         }
     }
@@ -536,7 +535,7 @@ fn array_builtin_last_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> 
     };
 
     for i in (0..=from_index as usize).rev() {
-        if let Some(true) = strict_eq(&input[i], &to_search, "===") {
+        if &input[i] == &to_search {
             return Some(Raw(Num(i as f64)));
         }
     }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -51,8 +51,11 @@ impl<'a> RuleMut<'a> for ParseArray {
 /// Centralized dispatcher for array literal builtins.
 type ArrayBuiltinHandler = fn(&Vec<JavaScript>, &[JavaScript]) -> Option<JavaScript>;
 
-const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] =
-    &[("at", array_builtin_at), ("concat", array_builtin_concat)];
+const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
+    ("at", array_builtin_at),
+    ("concat", array_builtin_concat),
+    ("copyWithin", array_builtin_copy_within),
+];
 
 #[derive(Default)]
 pub struct ArrayBuiltins;
@@ -154,6 +157,57 @@ fn array_builtin_concat(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<
             array.push(arg.clone());
         }
     }
+    Some(Array(array))
+}
+
+/// # `.copyWithin(x, y[, z])`
+/// No params = keep the array as is<br>
+/// `.copyWithin(x)` -> `.copyWithin(x, 0)`<br>
+/// `.copyWithin(x, y)` -> copy everything from x at y `[0,1,2,3,4,5,6].copyWithin(2,0)` -> `[0,1,0,1,2,3,4]`<br>
+/// `.copyWithin(x, y, z)` -> copy everything from x at y but limits to z elements `[0,1,2,3,4,5,6].copyWithin(2,0,3)` -> `[0,1,0,1,2,5,6]`
+fn array_builtin_copy_within(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    if args.is_empty() {
+        return Some(Array(input.clone()));
+    }
+
+    let len = input.len();
+
+    let target = match args[0].as_js_num() {
+        Raw(Num(n)) => n as usize,
+        NaN => 0usize,
+        _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+    };
+
+    let start = if args.len() >= 2 {
+        match args[1].as_js_num() {
+            Raw(Num(n)) => n as usize,
+            NaN => 0usize,
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    } else {
+        0usize
+    };
+
+    let end = if args.len() >= 3 {
+        match args[2].as_js_num() {
+            Raw(Num(n)) => n as usize,
+            NaN => return Some(Array(input.clone())),
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    } else {
+        len
+    };
+
+    let count = end.min(len).saturating_sub(start);
+
+    let mut array = input.clone();
+    for i in 0..count {
+        if target + i >= len {
+            break;
+        }
+        array[target + i] = input[start + i].clone();
+    }
+
     Some(Array(array))
 }
 
@@ -755,6 +809,42 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0,1,2].concat(1, 'a', ['b', ['c']])"),
             "var x = [0, 1, 2, 1, 'a', 'b', ['c']]"
+        );
+    }
+
+    #[test]
+    fn test_builtin_copy_within() {
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin()"),
+            "var x = [0, 1, 2, 3, 4, 5, 6]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin(2)"),
+            "var x = [0, 1, 0, 1, 2, 3, 4]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin('2')"),
+            "var x = [0, 1, 0, 1, 2, 3, 4]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin('??')"),
+            "var x = [0, 1, 2, 3, 4, 5, 6]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin(2, 3)"),
+            "var x = [0, 1, 3, 4, 5, 6, 6]"
+        ); // crash here
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin(2, '??')"),
+            "var x = [0, 1, 0, 1, 2, 3, 4]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin(2, 0, 3)"),
+            "var x = [0, 1, 0, 1, 2, 5, 6]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin(2, 0, '??')"),
+            "var x = [0, 1, 2, 3, 4, 5, 6]"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -64,6 +64,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("join", array_builtin_join),
     ("lastIndexOf", array_builtin_last_index_of),
     ("pop", array_builtin_pop),
+    ("push", array_builtin_push),
 ];
 
 #[derive(Default)]
@@ -297,6 +298,9 @@ fn unpack_array(values: &[JavaScript], depth: usize) -> Vec<JavaScript> {
     out
 }
 
+/// # `.includes(x)`
+/// No params = .includes(undefined)<br>
+/// Only returns Raw(Bool(b))
 fn array_builtin_includes(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     let to_search = if args.is_empty() {
         Undefined
@@ -314,6 +318,10 @@ fn array_builtin_includes(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     Some(Raw(Bool(false)))
 }
 
+/// # `.indexOf(x, y)`
+/// Default start = 0<br>
+/// returns -1 if not found<br>
+/// Only returns Raw(Num(n))
 fn array_builtin_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     let to_search = if args.is_empty() {
         Undefined
@@ -341,6 +349,10 @@ fn array_builtin_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     Some(Raw(Num(-1f64)))
 }
 
+/// # ``
+/// `.indexOf(x, y)` but searches backward<br>
+/// returns -1 if not found<br>
+/// Only returns Raw(Num(n))
 fn array_builtin_last_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     let to_search = if args.is_empty() {
         Undefined
@@ -401,14 +413,26 @@ fn array_builtin_join(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Ja
     Some(Raw(Str(flatten)))
 }
 
+/// # `.pop()`
+/// Removes and returns the last element <br>
+/// _(mutates array)_
 fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     if input.is_empty() {
         Some(Undefined)
     } else {
-        // todo the inpue must me mutbale or we need to find a way to alter the var manager
+        // todo the input must be mutable or we need to find a way to alter the var manager
         //Some(input.remove(input.len() - 1).clone())
         Some(input[input.len() - 1].clone())
     }
+}
+
+/// # `.push(thing1, ..., thingX)`
+/// Adds elements to end<br>
+/// returns the new length<br>
+/// _(mutates array)_
+fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    Some(Raw(Num((input.len() + args.len()) as f64)))
 }
 
 /// Infers `+` on two arrays
@@ -1131,8 +1155,22 @@ mod tests_js_array {
     }
 
     #[test]
-    fn test_builtin_poo() {
+    fn test_builtin_pop() {
         assert_eq!(deobfuscate("var x = [0].pop()"), "var x = 0");
         assert_eq!(deobfuscate("var x = [].pop()"), "var x = undefined");
+    }
+
+    #[test]
+    fn test_builtin_push() {
+        assert_eq!(deobfuscate("var x = [0,1,2,3].push()"), "var x = 4");
+        assert_eq!(deobfuscate("var x = [0,1,2,3].push(4)"), "var x = 5");
+        assert_eq!(
+            deobfuscate("var x = [0,1,2,3].push(undefined)"),
+            "var x = 5"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0,1,2,3].push(4,5,6,7,8,9)"),
+            "var x = 10"
+        );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -60,6 +60,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("fill", array_builtin_fill),
     ("flat", array_builtin_flat),
     ("includes", array_builtin_includes),
+    ("indexOf", array_builtin_index_of),
 ];
 
 #[derive(Default)]
@@ -308,6 +309,33 @@ fn array_builtin_includes(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     }
 
     Some(Raw(Bool(false)))
+}
+
+fn array_builtin_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let to_search = if args.is_empty() {
+        Undefined
+    } else {
+        args[0].clone()
+    };
+
+    let start = if args.len() >= 2 {
+        match args[1].as_js_num() {
+            Raw(Num(n)) => n as usize,
+            NaN => 0usize,
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    } else {
+        0usize
+    };
+
+    for (i, value) in input.iter().skip(start).enumerate() {
+        match strict_eq(value, &to_search, "===") {
+            Some(true) => return Some(Raw(Num((i + start) as f64))),
+            _ => {}
+        }
+    }
+
+    Some(Raw(Num(-1f64)))
 }
 
 /// Infers `+` on two arrays
@@ -823,7 +851,7 @@ mod tests_js_array {
     use crate::js::iterator::IteratorBuiltins;
     use crate::js::linter::Linter;
     use crate::js::objects::object::ObjectField;
-    use crate::js::specials::AddSubSpecials;
+    use crate::js::specials::{AddSubSpecials, ParseSpecials};
     use crate::js::string::BracketCharAt;
     use crate::js::string::ParseString;
 
@@ -833,6 +861,7 @@ mod tests_js_array {
             ParseInt::default(),
             ParseString::default(),
             ParseArray::default(),
+            ParseSpecials::default(),
             CombineArrays::default(),
             Forward::default(),
             Substract::default(),
@@ -1043,11 +1072,42 @@ mod tests_js_array {
 
     #[test]
     fn test_builtin_includes() {
-        assert_eq!(deobfuscate("var x = [0,1,2].includes()"), "var x = false");
-        assert_eq!(deobfuscate("var x = [0,1,2].includes(2)"), "var x = true");
+        assert_eq!(deobfuscate("var x = [0, 1, 2].includes()"), "var x = false");
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, undefined].includes()"),
+            "var x = true"
+        );
+        assert_eq!(deobfuscate("var x = [0, 1, 2].includes(2)"), "var x = true");
         assert_eq!(
             deobfuscate("var x = [0,1,2].includes('2')"),
             "var x = false"
+        );
+    }
+
+    #[test]
+    fn test_builtin_index_of() {
+        assert_eq!(deobfuscate("var x = [0, 1, 2].indexOf()"), "var x = -1");
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, undefined].indexOf()"),
+            "var x = 3"
+        );
+        assert_eq!(deobfuscate("var x = [0, 1, 2].indexOf(2)"), "var x = 2");
+        assert_eq!(deobfuscate("var x = [0,1,2].indexOf('2')"), "var x = -1");
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].indexOf(2)"),
+            "var x = 2"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].indexOf(2, 2)"),
+            "var x = 2"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].indexOf(2, 3)"),
+            "var x = 5"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].indexOf(2, '??')"),
+            "var x = 2"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -1,11 +1,11 @@
 use crate::error::MinusOneResult;
-use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::Bool;
 use crate::js::Value::{Num, Str};
 use crate::js::b64::js_bytes_to_string;
 use crate::js::comparator::strict_eq;
 use crate::js::utils::*;
+use crate::js::{IteratorKind, JavaScript};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{trace, warn};
@@ -76,6 +76,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
         Some(Raw(Str(flatten_array(arr, None))))
     }),
     ("unshift", array_builtin_unshift),
+    ("values", array_builtin_values),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -358,10 +359,19 @@ fn array_builtin_copy_within(input: &Vec<JavaScript>, args: &[JavaScript]) -> Op
     Some(Array(array))
 }
 
+fn array_builtin_values(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    Some(Iterator {
+        values: input.clone(),
+        index: 0,
+        kind: IteratorKind::Values,
+    })
+}
+
 fn array_builtin_entries(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     Some(Iterator {
         values: input.clone(),
         index: 0,
+        kind: IteratorKind::Entries,
     })
 }
 
@@ -1516,6 +1526,26 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0,1,2,3].unshift(4,5,6,7,8,9)"),
             "var x = 10"
+        );
+    }
+
+    #[test]
+    fn test_builtin_values() {
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2].values()"),
+            "var x = [object Array Iterator]"
+        );
+
+        let result = deobfuscate("var x = [0, 1, 2].values().next()");
+        if result.starts_with("var x = {v") {
+            assert_eq!(result, "var x = {value: 0, done: false}");
+        } else {
+            assert_eq!(result, "var x = {done: false, value: 0}");
+        }
+
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2].values().next().value"),
+            "var x = 0"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -51,7 +51,8 @@ impl<'a> RuleMut<'a> for ParseArray {
 /// Centralized dispatcher for array literal builtins.
 type ArrayBuiltinHandler = fn(&Vec<JavaScript>, &[JavaScript]) -> Option<JavaScript>;
 
-const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[("at", array_builtin_at)];
+const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] =
+    &[("at", array_builtin_at), ("concat", array_builtin_concat)];
 
 #[derive(Default)]
 pub struct ArrayBuiltins;
@@ -127,6 +128,8 @@ fn dispatch_array_builtin(
         .flatten()
 }
 
+/// ## `.at(x)`
+/// Handles negative index<br>overlapping pos/neg = `undefined`<br>no params = `.at(0)`
 fn array_builtin_at(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     let index = js_index_from_optional_arg(args.first());
     let len = input.len() as i64;
@@ -137,6 +140,21 @@ fn array_builtin_at(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Java
     }
 
     Some(input[normalized as usize].clone())
+}
+/// ## `.concat(thing1, ..., thingX)`
+/// no params = keep the array as is<br>
+/// can take any type of args<br>
+/// only unpack once the arrays `[0,1,2].concat(1, "a", ["b", ["c"]])` -> `[0, 1, 2, 1, 'a', 'b', ['c']]`
+fn array_builtin_concat(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let mut array = input.clone();
+    for arg in args {
+        if let Array(arr) = arg {
+            array.extend_from_slice(arr);
+        } else {
+            array.push(arg.clone());
+        }
+    }
+    Some(Array(array))
 }
 
 /// Infers `+` on two arrays
@@ -648,7 +666,7 @@ mod tests_js_array {
     use super::*;
     use crate::js::build_javascript_tree;
     use crate::js::forward::Forward;
-    use crate::js::integer::{ParseInt, Substract};
+    use crate::js::integer::{ParseInt, PosNeg, Substract};
     use crate::js::linter::Linter;
     use crate::js::specials::AddSubSpecials;
     use crate::js::string::BracketCharAt;
@@ -663,6 +681,8 @@ mod tests_js_array {
             CombineArrays::default(),
             Forward::default(),
             Substract::default(),
+            ArrayBuiltins::default(),
+            PosNeg::default(),
             GetArrayElement::default(),
             ArrayPlusMinus::default(),
             AddSubSpecials::default(),
@@ -716,5 +736,25 @@ mod tests_js_array {
     #[test]
     fn test_dont_reduce_array_lookup_when_used_as_callee() {
         assert_eq!(deobfuscate("var x = [][[]]();"), "var x = [][[]]();");
+    }
+
+    #[test]
+    fn test_builtin_at() {
+        assert_eq!(deobfuscate("var x = [0,1,2].at()"), "var x = 0");
+        assert_eq!(deobfuscate("var x = [0,1,2].at(2)"), "var x = 2");
+        assert_eq!(deobfuscate("var x = [0,1,2].at(3)"), "var x = undefined");
+        assert_eq!(deobfuscate("var x = [0,1,2].at(-1)"), "var x = 2");
+        assert_eq!(deobfuscate("var x = [0,1,2].at(-3)"), "var x = 0");
+        assert_eq!(deobfuscate("var x = [0,1,2].at(-4)"), "var x = undefined");
+    }
+
+    #[test]
+    fn test_builtin_concat() {
+        assert_eq!(deobfuscate("var x = [0].concat()"), "var x = [0]");
+        assert_eq!(deobfuscate("var x = [0].concat(1)"), "var x = [0, 1]");
+        assert_eq!(
+            deobfuscate("var x = [0,1,2].concat(1, 'a', ['b', ['c']])"),
+            "var x = [0, 1, 2, 1, 'a', 'b', ['c']]"
+        );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -9,6 +9,7 @@ use crate::js::utils::*;
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{trace, warn};
+use std::clone::Clone;
 
 /// Parses JavaScript array literals into `Array(_)`.
 #[derive(Default)]
@@ -71,6 +72,9 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("sort", array_builtin_sort),
     ("toReversed", array_builtin_to_reversed),
     ("toSorted", array_builtin_to_sorted),
+    ("toString", |arr, _| {
+        Some(Raw(Str(flatten_array(arr, None))))
+    }),
 ];
 
 fn is_array_builtin(method: &str) -> bool {

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -65,6 +65,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("lastIndexOf", array_builtin_last_index_of),
     ("pop", array_builtin_pop),
     ("push", array_builtin_push),
+    ("reverse", array_builtin_reverse),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -559,6 +560,15 @@ fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<Ja
 fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
     Some(Raw(Num((input.len() + args.len()) as f64)))
+}
+
+/// # `.reverse()`
+/// Reverse othe order of the array and also return it<br>
+/// _(mutates array)_
+fn array_builtin_reverse(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    let new_array = input.iter().rev().cloned().collect();
+    Some(Array(new_array))
 }
 
 /// Infers `+` on two arrays
@@ -1311,5 +1321,15 @@ mod tests_js_array {
             deobfuscate("var x = undefined + [0].pop"),
             "var x = 'undefinedfunction pop() { [native code] }'"
         );
+    }
+
+    #[test]
+    fn test_builtin_reverse() {
+        assert_eq!(
+            deobfuscate("var x = [0,1,2,3].reverse()"),
+            "var x = [3, 2, 1, 0]"
+        );
+        assert_eq!(deobfuscate("var x = [0].reverse()"), "var x = [0]");
+        assert_eq!(deobfuscate("var x = [].reverse()"), "var x = []");
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -4,6 +4,7 @@ use crate::js::JavaScript::*;
 use crate::js::Value::Bool;
 use crate::js::Value::{Num, Str};
 use crate::js::b64::js_bytes_to_string;
+use crate::js::comparator::strict_eq;
 use crate::js::utils::{get_positional_arguments, js_index_from_optional_arg, method_name};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
@@ -58,6 +59,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("entries", array_builtin_entries),
     ("fill", array_builtin_fill),
     ("flat", array_builtin_flat),
+    ("includes", array_builtin_includes),
 ];
 
 #[derive(Default)]
@@ -289,6 +291,23 @@ fn unpack_array(values: &[JavaScript], depth: usize) -> Vec<JavaScript> {
         }
     }
     out
+}
+
+fn array_builtin_includes(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let to_search = if args.is_empty() {
+        Undefined
+    } else {
+        args[0].clone()
+    };
+
+    for value in input {
+        match strict_eq(value, &to_search, "===") {
+            Some(true) => return Some(Raw(Bool(true))),
+            _ => {}
+        }
+    }
+
+    Some(Raw(Bool(false)))
 }
 
 /// Infers `+` on two arrays
@@ -1019,6 +1038,16 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat(Infinity)"),
             "var x = [0, 1, 2, 3, 4, 5]"
+        );
+    }
+
+    #[test]
+    fn test_builtin_includes() {
+        assert_eq!(deobfuscate("var x = [0,1,2].includes()"), "var x = false");
+        assert_eq!(deobfuscate("var x = [0,1,2].includes(2)"), "var x = true");
+        assert_eq!(
+            deobfuscate("var x = [0,1,2].includes('2')"),
+            "var x = false"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -63,6 +63,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("indexOf", array_builtin_index_of),
     ("join", array_builtin_join),
     ("lastIndexOf", array_builtin_last_index_of),
+    ("pop", array_builtin_pop),
 ];
 
 #[derive(Default)]
@@ -398,6 +399,16 @@ fn array_builtin_join(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Ja
 
     let flatten = flatten_array(input, separator);
     Some(Raw(Str(flatten)))
+}
+
+fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    if input.is_empty() {
+        Some(Undefined)
+    } else {
+        // todo the inpue must me mutbale or we need to find a way to alter the var manager
+        //Some(input.remove(input.len() - 1).clone())
+        Some(input[input.len() - 1].clone())
+    }
 }
 
 /// Infers `+` on two arrays
@@ -1117,5 +1128,11 @@ mod tests_js_array {
             deobfuscate("var x = [0, 1, 2, 0, 1, 2].lastIndexOf(2, '??')"),
             "var x = -1"
         );
+    }
+
+    #[test]
+    fn test_builtin_poo() {
+        assert_eq!(deobfuscate("var x = [0].pop()"), "var x = 0");
+        assert_eq!(deobfuscate("var x = [].pop()"), "var x = undefined");
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -1548,4 +1548,10 @@ mod tests_js_array {
             "var x = 0"
         );
     }
+
+    #[test]
+    fn test_builtin_length() {
+        assert_eq!(deobfuscate("var x = [0, 1, 2].length"), "var x = 3");
+        assert_eq!(deobfuscate("var x = [].length"), "var x = 0");
+    }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -89,18 +89,18 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("indexOf", array_builtin_index_of),
     ("join", array_builtin_join),
     ("lastIndexOf", array_builtin_last_index_of),
-    ("pop", array_builtin_pop),
-    ("push", array_builtin_push),
-    ("reverse", array_builtin_reverse),
-    ("shift", array_builtin_shift),
+    // ("pop", array_builtin_pop),
+    // ("push", array_builtin_push),
+    // ("reverse", array_builtin_reverse),
+    // ("shift", array_builtin_shift),
     ("slice", array_builtin_slice),
-    ("sort", array_builtin_sort),
+    // ("sort", array_builtin_sort),
     ("toReversed", array_builtin_to_reversed),
     ("toSorted", array_builtin_to_sorted),
     ("toString", |arr, _| {
         Some(Raw(Str(flatten_array(arr, None))))
     }),
-    ("unshift", array_builtin_unshift),
+    // ("unshift", array_builtin_unshift),
     ("values", array_builtin_values),
 ];
 
@@ -585,7 +585,7 @@ fn array_builtin_join(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Ja
     Some(Raw(Str(flatten)))
 }
 
-/// # `.pop()`
+/*/// # `.pop()`
 /// Removes and returns the last element <br>
 /// _(mutates array)_
 fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
@@ -594,23 +594,23 @@ fn array_builtin_pop(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<Ja
     } else {
         Some(input[input.len() - 1].clone())
     }
-}
+}*/
 
-/// # `.push(thing1, ..., thingX)`
+/*/// # `.push(thing1, ..., thingX)`
 /// Adds elements to end<br>
 /// returns the new length<br>
 /// _(mutates array)_
 fn array_builtin_push(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     Some(Raw(Num((input.len() + args.len()) as f64)))
-}
+}*/
 
-/// # `.reverse()`
+/*/// # `.reverse()`
 /// Reverse othe order of the array and also return it<br>
 /// _(mutates array)_
 fn array_builtin_reverse(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
     let new_array = input.iter().rev().cloned().collect();
     Some(Array(new_array))
-}
+}*/
 
 /// # `.toReversed()`
 /// `.reverse()` but create a copy so it does *not mutate* the original array
@@ -619,7 +619,7 @@ fn array_builtin_to_reversed(input: &Vec<JavaScript>, _args: &[JavaScript]) -> O
     Some(Array(new_array))
 }
 
-/// # `.shift()`
+/*/// # `.shift()`
 /// Removes and returns first element<br>
 /// _(mutates array)_
 fn array_builtin_shift(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
@@ -628,7 +628,7 @@ fn array_builtin_shift(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<
     } else {
         Some(input[0].clone())
     }
-}
+}*/
 
 /// # `.slice(start[, end])`
 ///  Handles negative indices<br>
@@ -668,7 +668,7 @@ fn array_builtin_slice(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<J
     Some(Array(result))
 }
 
-/// # `.sort([customSortFn])`
+/*/// # `.sort([customSortFn])`
 /// Sort the array (`to_string` based ??)<br>
 /// _(mutates array)_
 fn array_builtin_sort(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
@@ -679,7 +679,7 @@ fn array_builtin_sort(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<Ja
     let mut new_array = input.clone();
     new_array.sort_by(|a, b| as_known_string(a).cmp(&as_known_string(b)));
     Some(Array(new_array))
-}
+}*/
 
 /// # `.toSorted([customSortFn])`
 /// `.sort([customSortFn])` but create a copy so it does *not mutate* the original array
@@ -693,13 +693,13 @@ fn array_builtin_to_sorted(input: &Vec<JavaScript>, args: &[JavaScript]) -> Opti
     Some(Array(new_array))
 }
 
-/// # `.unshift(thing1, ..., thingX)`
+/*/// # `.unshift(thing1, ..., thingX)`
 /// Adds elements to start<br>
 /// returns new length<br>
 /// _(mutates array)_
 fn array_builtin_unshift(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
     Some(Raw(Num((args.len() + input.len()) as f64)))
-}
+}*/
 
 /// Infers `+` on two arrays
 ///
@@ -1420,13 +1420,13 @@ mod tests_js_array {
         );
     }
 
-    #[test]
+    /*#[test]
     fn test_builtin_pop() {
         assert_eq!(deobfuscate("var x = [0].pop()"), "var x = 0");
         assert_eq!(deobfuscate("var x = [].pop()"), "var x = undefined");
-    }
+    }*/
 
-    #[test]
+    /*#[test]
     fn test_builtin_push() {
         assert_eq!(deobfuscate("var x = [0,1,2,3].push()"), "var x = 4");
         assert_eq!(deobfuscate("var x = [0,1,2,3].push(4)"), "var x = 5");
@@ -1438,10 +1438,9 @@ mod tests_js_array {
             deobfuscate("var x = [0,1,2,3].push(4,5,6,7,8,9)"),
             "var x = 10"
         );
-    }
+    }*/
 
-    #[test]
-    // todo: implements for other builtins
+    /*#[test]
     fn test_convert_builtin_to_string() {
         assert_eq!(
             deobfuscate("var x = [0].pop + ''"),
@@ -1451,9 +1450,9 @@ mod tests_js_array {
             deobfuscate("var x = undefined + [0].pop"),
             "var x = 'undefinedfunction pop() { [native code] }'"
         );
-    }
+    }*/
 
-    #[test]
+    /*#[test]
     fn test_builtin_reverse() {
         assert_eq!(
             deobfuscate("var x = [0,1,2,3].reverse()"),
@@ -1461,7 +1460,7 @@ mod tests_js_array {
         );
         assert_eq!(deobfuscate("var x = [0].reverse()"), "var x = [0]");
         assert_eq!(deobfuscate("var x = [].reverse()"), "var x = []");
-    }
+    }*/
 
     #[test]
     fn test_builtin_to_reversed() {
@@ -1473,11 +1472,11 @@ mod tests_js_array {
         assert_eq!(deobfuscate("var x = [].toReversed()"), "var x = []");
     }
 
-    #[test]
+    /*#[test]
     fn test_builtin_shift() {
         assert_eq!(deobfuscate("var x = [0].shift()"), "var x = 0");
         assert_eq!(deobfuscate("var x = [].shift()"), "var x = undefined");
-    }
+    }*/
 
     #[test]
     fn test_builtin_slice() {
@@ -1511,7 +1510,7 @@ mod tests_js_array {
         );
     }
 
-    #[test]
+    /*#[test]
     fn test_builtin_sort() {
         assert_eq!(
             deobfuscate("var x = [0, 8, 7, 3].sort()"),
@@ -1523,7 +1522,7 @@ mod tests_js_array {
             deobfuscate("var x = [9, 10, 11].sort()"),
             "var x = [10, 11, 9]"
         ); // to_string moment...
-    }
+    }*/
 
     #[test]
     fn test_builtin_to_sorted() {
@@ -1539,7 +1538,7 @@ mod tests_js_array {
         ); // to_string moment...
     }
 
-    #[test]
+    /*#[test]
     fn test_builtin_unshift() {
         assert_eq!(deobfuscate("var x = [0,1,2,3].unshift()"), "var x = 4");
         assert_eq!(deobfuscate("var x = [0,1,2,3].unshift(4)"), "var x = 5");
@@ -1551,7 +1550,7 @@ mod tests_js_array {
             deobfuscate("var x = [0,1,2,3].unshift(4,5,6,7,8,9)"),
             "var x = 10"
         );
-    }
+    }*/
 
     #[test]
     fn test_builtin_values() {

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -67,6 +67,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("push", array_builtin_push),
     ("reverse", array_builtin_reverse),
     ("shift", array_builtin_shift),
+    ("slice", array_builtin_slice),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -582,6 +583,44 @@ fn array_builtin_shift(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<
     } else {
         Some(input[0].clone())
     }
+}
+
+/// # `.slice(start[, end])`
+///  Handles negative indices<br>
+/// no params = `.slice(0)`<br>
+/// Extracts from `n1` to `n2` (exclusive)<br>
+/// returns a copy
+fn array_builtin_slice(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let len = input.len() as isize;
+
+    let start = match args.first().map(|a| a.as_js_num()) {
+        Some(Raw(Num(n))) => n as isize,
+        _ => 0,
+    };
+
+    let end = match args.get(1).map(|a| a.as_js_num()) {
+        Some(Raw(Num(n))) => n as isize,
+        _ => len,
+    };
+
+    let start = if start < 0 {
+        (len + start).max(0) as usize
+    } else {
+        start as usize
+    };
+    let end = if end < 0 {
+        (len + end).max(0) as usize
+    } else {
+        end as usize
+    };
+
+    if start >= end || start >= input.len() {
+        return Some(Array(vec![]));
+    }
+
+    let end = end.min(input.len());
+    let result = input[start..end].to_vec();
+    Some(Array(result))
 }
 
 /// Infers `+` on two arrays
@@ -1350,5 +1389,37 @@ mod tests_js_array {
     fn test_builtin_shift() {
         assert_eq!(deobfuscate("var x = [0].shift()"), "var x = 0");
         assert_eq!(deobfuscate("var x = [].shift()"), "var x = undefined");
+    }
+
+    #[test]
+    fn test_builtin_slice() {
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice(1, 4);"),
+            "var x = [1, 2, 3];"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice(2);"),
+            "var x = [2, 3, 4, 5];"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice(-3);"),
+            "var x = [3, 4, 5];"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice(-4, -1);"),
+            "var x = [2, 3, 4];"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice(2, 1);"),
+            "var x = [];"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice(10);"),
+            "var x = [];"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 3, 4, 5].slice();"),
+            "var x = [0, 1, 2, 3, 4, 5];"
+        );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -5,9 +5,9 @@ use crate::js::Value::Bool;
 use crate::js::Value::{Num, Str};
 use crate::js::b64::js_bytes_to_string;
 use crate::js::comparator::strict_eq;
-use crate::js::utils::{get_positional_arguments, js_index_from_optional_arg, method_name};
+use crate::js::utils::*;
 use crate::rule::RuleMut;
-use crate::tree::{ControlFlow, NodeMut};
+use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{trace, warn};
 
 /// Parses JavaScript array literals into `Array(_)`.
@@ -67,6 +67,77 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("push", array_builtin_push),
 ];
 
+fn is_array_builtin(method: &str) -> bool {
+    ARRAY_BUILTINS.iter().any(|(name, _)| *name == method)
+}
+
+fn property_name(node: &Node<JavaScript>) -> Option<String> {
+    match node.kind() {
+        "member_expression" => method_name(node),
+        "subscript_expression" => {
+            let index = node.child(2).or_else(|| node.named_child("index"))?;
+            let Some(Raw(Str(name))) = index.data() else {
+                return None;
+            };
+            Some(name.clone())
+        }
+        _ => None,
+    }
+}
+
+fn property_object<'a>(node: &'a Node<'a, JavaScript>) -> Option<Node<'a, JavaScript>> {
+    match node.kind() {
+        "member_expression" | "subscript_expression" => {
+            node.child(0).or_else(|| node.named_child("object"))
+        }
+        _ => None,
+    }
+}
+
+fn array_builtin_name_from_ref(node: &Node<JavaScript>) -> Option<String> {
+    let method = property_name(node)?;
+    if !is_array_builtin(&method) {
+        return None;
+    }
+
+    let object = property_object(node)?;
+    let Some(Array(_)) = object.data() else {
+        return None;
+    };
+
+    Some(method)
+}
+
+fn array_builtin_native_source(node: &Node<JavaScript>) -> Option<String> {
+    let method = array_builtin_name_from_ref(node)?;
+    Some(format!("function {method}() {{ [native code] }}"))
+}
+
+fn is_array_builtin_constructor_name_chain(node: &Node<JavaScript>) -> bool {
+    let Some(last_prop) = property_name(node) else {
+        return false;
+    };
+    if last_prop != "name" {
+        return false;
+    }
+
+    let Some(constructor_node) = property_object(node) else {
+        return false;
+    };
+    let Some(constructor_prop) = property_name(&constructor_node) else {
+        return false;
+    };
+    if constructor_prop != "constructor" {
+        return false;
+    }
+
+    let Some(base_node) = property_object(&constructor_node) else {
+        return false;
+    };
+
+    array_builtin_name_from_ref(&base_node).is_some()
+}
+
 #[derive(Default)]
 pub struct ArrayBuiltins;
 
@@ -87,45 +158,100 @@ impl<'a> RuleMut<'a> for ArrayBuiltins {
         _flow: ControlFlow,
     ) -> MinusOneResult<()> {
         let view = node.view();
-        if view.kind() != "call_expression" {
-            return Ok(());
-        }
 
-        let Some(callee) = view.named_child("function").or_else(|| view.child(0)) else {
-            return Ok(());
-        };
-        let Some(method) = method_name(&callee) else {
-            return Ok(());
-        };
-
-        let Some(object) = callee.child(0).or_else(|| callee.named_child("object")) else {
-            return Ok(());
-        };
-        let Some(Array(input)) = object.data() else {
-            return Ok(());
-        };
-
-        let args = view.named_child("arguments");
-        let positional_args = get_positional_arguments(args);
-        let mut arg_values = Vec::with_capacity(positional_args.len());
-        for arg in positional_args {
-            let Some(value) = arg.data().cloned() else {
+        if view.kind() == "call_expression" {
+            let Some(callee) = view.named_child("function").or_else(|| view.child(0)) else {
                 return Ok(());
             };
-            arg_values.push(value);
+            let Some(method) = method_name(&callee) else {
+                return Ok(());
+            };
+            let Some(object) = callee.child(0).or_else(|| callee.named_child("object")) else {
+                return Ok(());
+            };
+            let Some(Array(input)) = object.data() else {
+                return Ok(());
+            };
+
+            let args = view.named_child("arguments");
+            let positional_args = get_positional_arguments(args);
+            let mut arg_values = Vec::with_capacity(positional_args.len());
+            for arg in positional_args {
+                let Some(value) = arg.data().cloned() else {
+                    return Ok(());
+                };
+                arg_values.push(value);
+            }
+
+            let Some(result) = dispatch_array_builtin(&method, input, &arg_values) else {
+                return Ok(());
+            };
+
+            trace!(
+                "ArrayBuiltins: reducing '{}'.{}(...) to {}",
+                Array(input.clone()),
+                method,
+                result
+            );
+            node.reduce(result);
+            return Ok(());
         }
 
-        let Some(result) = dispatch_array_builtin(&method, input, &arg_values) else {
+        if is_array_builtin_constructor_name_chain(&view) {
+            let result = Raw(Str("Function".to_string()));
+            trace!(
+                "ArrayBuiltins: reducing array builtin constructor.name chain to {}",
+                result
+            );
+            node.reduce(result);
             return Ok(());
-        };
+        }
 
-        trace!(
-            "ArrayBuiltins: reducing '{}'.{}(...) to {}",
-            Array(input.clone()),
-            method,
-            result
-        );
-        node.reduce(result);
+        if view.kind() == "binary_expression" {
+            let left = view.child(0);
+            let right = view.child(2);
+            let operator = view.child(1);
+
+            let (Some(left), Some(right), Some(operator)) = (left, right, operator) else {
+                return Ok(());
+            };
+
+            if operator.kind() != "+" && operator.text()? != "+" {
+                return Ok(());
+            }
+
+            let left_data = left.data().cloned();
+            let right_data = right.data().cloned();
+
+            if let (Some(left_src), Some(right_value)) =
+                (array_builtin_native_source(&left), right_data.as_ref())
+            {
+                let result = Raw(Str(
+                    format!("{}{}", left_src, as_known_string(right_value),),
+                ));
+                trace!(
+                    "ArrayBuiltins: reducing builtin string concat to {}",
+                    result
+                );
+                node.reduce(result);
+                return Ok(());
+            }
+
+            if let (Some(left_value), Some(right_src)) =
+                (left_data.as_ref(), array_builtin_native_source(&right))
+            {
+                let result = Raw(Str(
+                    format!("{}{}", as_known_string(left_value), right_src,),
+                ));
+                trace!(
+                    "ArrayBuiltins: reducing builtin string concat to {}",
+                    result
+                );
+                node.reduce(result);
+                return Ok(());
+            }
+        }
+
         Ok(())
     }
 }
@@ -1171,6 +1297,19 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0,1,2,3].push(4,5,6,7,8,9)"),
             "var x = 10"
+        );
+    }
+
+    #[test]
+    // todo: implements for other builtins
+    fn test_convert_builtin_to_string() {
+        assert_eq!(
+            deobfuscate("var x = [0].pop + ''"),
+            "var x = 'function pop() { [native code] }'"
+        );
+        assert_eq!(
+            deobfuscate("var x = undefined + [0].pop"),
+            "var x = 'undefinedfunction pop() { [native code] }'"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -55,6 +55,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("at", array_builtin_at),
     ("concat", array_builtin_concat),
     ("copyWithin", array_builtin_copy_within),
+    ("entries", array_builtin_entries),
 ];
 
 #[derive(Default)]
@@ -209,6 +210,13 @@ fn array_builtin_copy_within(input: &Vec<JavaScript>, args: &[JavaScript]) -> Op
     }
 
     Some(Array(array))
+}
+
+fn array_builtin_entries(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    Some(Iterator {
+        values: input.clone(),
+        index: 0,
+    })
 }
 
 /// Infers `+` on two arrays
@@ -721,7 +729,9 @@ mod tests_js_array {
     use crate::js::build_javascript_tree;
     use crate::js::forward::Forward;
     use crate::js::integer::{ParseInt, PosNeg, Substract};
+    use crate::js::iterator::IteratorBuiltins;
     use crate::js::linter::Linter;
+    use crate::js::objects::object::ObjectField;
     use crate::js::specials::AddSubSpecials;
     use crate::js::string::BracketCharAt;
     use crate::js::string::ParseString;
@@ -736,7 +746,9 @@ mod tests_js_array {
             Forward::default(),
             Substract::default(),
             ArrayBuiltins::default(),
+            IteratorBuiltins::default(),
             PosNeg::default(),
+            //ObjectField::default(),
             GetArrayElement::default(),
             ArrayPlusMinus::default(),
             AddSubSpecials::default(),
@@ -845,6 +857,27 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0, 1, 2, 3, 4, 5, 6].copyWithin(2, 0, '??')"),
             "var x = [0, 1, 2, 3, 4, 5, 6]"
+        );
+    }
+
+    #[test]
+    fn test_builtin_entries() {
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2].entries()"),
+            "var x = [object Array Iterator]"
+        );
+
+        // Order of the fields is random ??
+        let result = deobfuscate("var x = [0, 1, 2].entries().next()");
+        if result.starts_with("var x = {v") {
+            assert_eq!(result, "var x = {value: [0, 0], done: false}");
+        } else {
+            assert_eq!(result, "var x = {done: false, value: [0, 0]}");
+        }
+
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2].entries().next().value"),
+            "var x = [0, 0]"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -66,6 +66,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("pop", array_builtin_pop),
     ("push", array_builtin_push),
     ("reverse", array_builtin_reverse),
+    ("shift", array_builtin_shift),
 ];
 
 fn is_array_builtin(method: &str) -> bool {
@@ -569,6 +570,18 @@ fn array_builtin_reverse(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Optio
     // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
     let new_array = input.iter().rev().cloned().collect();
     Some(Array(new_array))
+}
+
+/// # `.shift()`
+/// Removes and returns first element<br>
+/// _(mutates array)_
+fn array_builtin_shift(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Option<JavaScript> {
+    // todo the input must be mutable or we need to find a way to alter the var manager. since it's not possible atm, we just return the expected value
+    if input.is_empty() {
+        Some(Undefined)
+    } else {
+        Some(input[0].clone())
+    }
 }
 
 /// Infers `+` on two arrays
@@ -1331,5 +1344,11 @@ mod tests_js_array {
         );
         assert_eq!(deobfuscate("var x = [0].reverse()"), "var x = [0]");
         assert_eq!(deobfuscate("var x = [].reverse()"), "var x = []");
+    }
+
+    #[test]
+    fn test_builtin_shift() {
+        assert_eq!(deobfuscate("var x = [0].shift()"), "var x = 0");
+        assert_eq!(deobfuscate("var x = [].shift()"), "var x = undefined");
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -56,6 +56,8 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("concat", array_builtin_concat),
     ("copyWithin", array_builtin_copy_within),
     ("entries", array_builtin_entries),
+    ("fill", array_builtin_fill),
+    ("flat", array_builtin_flat),
 ];
 
 #[derive(Default)]
@@ -217,6 +219,76 @@ fn array_builtin_entries(input: &Vec<JavaScript>, _args: &[JavaScript]) -> Optio
         values: input.clone(),
         index: 0,
     })
+}
+
+/// # `.fill(x[, y[, z]])`
+/// No params = fill with `undefined`<br>
+/// `.fill(x)` fill the array with x<br>
+/// `fill(x, y)` -> fill the array with x from y `[0,1,2,3].fill(9,1)` -> `[0,9,9,9]`<br>
+/// `fill(x, y, z)` -> fill the array with x from y to z `[0,1,2,3,5].fill(9,1,4)` -> `[0,9,9,9,5]`
+fn array_builtin_fill(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let fill_with = if args.is_empty() {
+        Undefined
+    } else {
+        args[0].clone()
+    };
+
+    let start = if args.len() >= 2 {
+        match args[1].as_js_num() {
+            Raw(Num(n)) => n as usize,
+            NaN => 0usize,
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    } else {
+        0usize
+    };
+
+    let end = if args.len() >= 3 {
+        match args[2].as_js_num() {
+            Raw(Num(n)) => n as usize,
+            NaN => 0usize,
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    } else {
+        input.len()
+    };
+
+    let mut array = input.clone();
+    for i in start..end {
+        array[i] = fill_with.clone();
+    }
+
+    Some(Array(array))
+}
+
+/// # `.flat(x)`
+///  No args -> `.flat(1)`<br>
+/// recursively unpack x times arrays in arrays `[0,1,[2,[3,[4,5]]]].flat(2)` -> `[0,1,2,3,[4,5]]`
+fn array_builtin_flat(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let depth = if args.is_empty() {
+        1usize
+    } else {
+        match args[0].as_js_num() {
+            Raw(Num(n)) => n as usize,
+            NaN => 0usize,
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    };
+
+    Some(Array(unpack_array(input, depth)))
+}
+
+fn unpack_array(values: &[JavaScript], depth: usize) -> Vec<JavaScript> {
+    let mut out = Vec::new();
+    for value in values {
+        match value {
+            Array(arr) if depth > 0 => {
+                out.extend(unpack_array(arr, depth - 1));
+            }
+            other => out.push(other.clone()),
+        }
+    }
+    out
 }
 
 /// Infers `+` on two arrays
@@ -748,7 +820,7 @@ mod tests_js_array {
             ArrayBuiltins::default(),
             IteratorBuiltins::default(),
             PosNeg::default(),
-            //ObjectField::default(),
+            ObjectField::default(),
             GetArrayElement::default(),
             ArrayPlusMinus::default(),
             AddSubSpecials::default(),
@@ -878,6 +950,75 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0, 1, 2].entries().next().value"),
             "var x = [0, 0]"
+        );
+    }
+
+    #[test]
+    fn test_builtin_fill() {
+        assert_eq!(deobfuscate("var x = [].fill()"), "var x = []");
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3].fill()"),
+            "var x = [undefined, undefined, undefined]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3].fill(0)"),
+            "var x = [0, 0, 0]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3].fill(0, 1)"),
+            "var x = [1, 0, 0]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3].fill(0, '??')"),
+            "var x = [0, 0, 0]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3, 4, 5].fill(0, 1, 4)"),
+            "var x = [1, 0, 0, 0, 5]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3, 4, 5].fill(0, 1, '??')"),
+            "var x = [1, 2, 3, 4, 5]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3, 4, 5].fill(0, '??', 4)"),
+            "var x = [0, 0, 0, 0, 5]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [1, 2, 3, 4, 5].fill(0, '??', '??')"),
+            "var x = [1, 2, 3, 4, 5]"
+        );
+    }
+
+    #[test]
+    fn test_builtin_flat() {
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat()"),
+            "var x = [0, 1, 2, [3, [4, 5]]]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat(0)"),
+            "var x = [0, 1, [2, [3, [4, 5]]]]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat(1)"),
+            "var x = [0, 1, 2, [3, [4, 5]]]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat(2)"),
+            "var x = [0, 1, 2, 3, [4, 5]]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat('??')"),
+            "var x = [0, 1, [2, [3, [4, 5]]]]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat(-1)"),
+            "var x = [0, 1, [2, [3, [4, 5]]]]"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, [2, [3, [4, 5]]]].flat(Infinity)"),
+            "var x = [0, 1, 2, 3, 4, 5]"
         );
     }
 }

--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -62,6 +62,7 @@ const ARRAY_BUILTINS: &[(&str, ArrayBuiltinHandler)] = &[
     ("includes", array_builtin_includes),
     ("indexOf", array_builtin_index_of),
     ("join", array_builtin_join),
+    ("lastIndexOf", array_builtin_last_index_of),
 ];
 
 #[derive(Default)]
@@ -337,6 +338,50 @@ fn array_builtin_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Optio
     }
 
     Some(Raw(Num(-1f64)))
+}
+
+fn array_builtin_last_index_of(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
+    let to_search = if args.is_empty() {
+        Undefined
+    } else {
+        args[0].clone()
+    };
+
+    let len = input.len();
+    if len == 0 {
+        return Some(Raw(Num(-1.0)));
+    }
+
+    let from_index = if args.len() >= 2 {
+        match args[1].as_js_num() {
+            Raw(Num(n)) => {
+                let n = n.trunc() as isize;
+                if n >= len as isize {
+                    len as isize - 1
+                } else if n < 0 {
+                    let idx = len as isize + n;
+                    if idx < 0 {
+                        return Some(Raw(Num(-1.0)));
+                    }
+                    idx
+                } else {
+                    n
+                }
+            }
+            NaN => 0,
+            _ => unreachable!("The result of as_js_num should be either Raw(Num(x)) or NaN"),
+        }
+    } else {
+        len as isize - 1
+    };
+
+    for i in (0..=from_index as usize).rev() {
+        if let Some(true) = strict_eq(&input[i], &to_search, "===") {
+            return Some(Raw(Num(i as f64)));
+        }
+    }
+
+    Some(Raw(Num(-1.0)))
 }
 
 fn array_builtin_join(input: &Vec<JavaScript>, args: &[JavaScript]) -> Option<JavaScript> {
@@ -1041,6 +1086,36 @@ mod tests_js_array {
         assert_eq!(
             deobfuscate("var x = [0, 1, 2, 0, 1, 2].indexOf(2, '??')"),
             "var x = 2"
+        );
+    }
+
+    #[test]
+    fn test_builtin_last_index_of() {
+        assert_eq!(deobfuscate("var x = [0, 1, 2].lastIndexOf()"), "var x = -1");
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, undefined].lastIndexOf()"),
+            "var x = 3"
+        );
+        assert_eq!(deobfuscate("var x = [0, 1, 2].lastIndexOf(2)"), "var x = 2");
+        assert_eq!(
+            deobfuscate("var x = [0,1,2].lastIndexOf('2')"),
+            "var x = -1"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].lastIndexOf(2)"),
+            "var x = 5"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].lastIndexOf(2, 2)"),
+            "var x = 2"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].lastIndexOf(2, 3)"),
+            "var x = 2"
+        );
+        assert_eq!(
+            deobfuscate("var x = [0, 1, 2, 0, 1, 2].lastIndexOf(2, '??')"),
+            "var x = -1"
         );
     }
 }

--- a/core/src/js/b64.rs
+++ b/core/src/js/b64.rs
@@ -183,7 +183,6 @@ mod tests_js_b64 {
             bytes.push(i);
         }
         let decoded_string = js_bytes_to_string(&bytes);
-        println!("{}", decoded_string);
         assert_eq!(
             decoded_string,
             "\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\b\\t\\n\\v\\f\\r\\x0E\\x0F\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1A\\x1B\\x1C\\x1D\\x1E\\x1F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7F\\x80\\x81\\x82\\x83\\x84\\x85\\x86\\x87\\x88\\x89\\x8A\\x8B\\x8C\\x8D\\x8E\\x8F\\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9A\\x9B\\x9C\\x9D\\x9E\\x9F ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"

--- a/core/src/js/comparator.rs
+++ b/core/src/js/comparator.rs
@@ -59,74 +59,20 @@ impl<'a> RuleMut<'a> for StrictEq {
             }
 
             if let (Some(left), Some(right)) = (left.data(), right.data()) {
-                let eq = strict_eq(left, right, op_str);
+                //let eq = strict_eq(left, right, op_str);
+                let eq = if op_str == "===" {
+                    left == right
+                } else {
+                    left != right
+                };
 
-                if let Some(is_eq) = eq {
-                    let result = if op_str == "===" { is_eq } else { !is_eq };
-                    trace!("StrictEq (L): result = {}", result);
-                    node.reduce(Raw(Bool(result)));
-                }
+                trace!("StrictEq (L): result = {}", eq);
+                node.reduce(Raw(Bool(eq)));
             }
         }
 
         Ok(())
     }
-}
-
-pub fn strict_eq(left: &JavaScript, right: &JavaScript, op_str: &str) -> Option<bool> {
-    let eq: Option<bool> = match (left, right) {
-        (Raw(Num(l)), Raw(Num(r))) => {
-            trace!("StrictEq (L): {} {} {} = {}", l, op_str, r, l == r);
-            Some(l == r)
-        }
-        (Raw(BigInt(l)), Raw(BigInt(r))) => {
-            trace!("StrictEq (L): {}n {} {}n = {}", l, op_str, r, l == r);
-            Some(l == r)
-        }
-        (Raw(Str(l)), Raw(Str(r))) => {
-            trace!("StrictEq (L): {:?} {} {:?} = {}", l, op_str, r, l == r);
-            Some(l == r)
-        }
-        (Raw(Bool(l)), Raw(Bool(r))) => {
-            trace!("StrictEq (L): {} {} {} = {}", l, op_str, r, l == r);
-            Some(l == r)
-        }
-        (Undefined, Undefined) => {
-            let res = op_str == "===";
-            trace!("StrictEq (L): undefined {} undefined = {}", op_str, res);
-            Some(res)
-        }
-        (Null, Null) => {
-            let res = op_str == "===";
-            trace!("StrictEq (L): null {} null = {}", op_str, res);
-            Some(res)
-        }
-        // NaN is never strictly equal to anything, including itself ??
-        (NaN, _) | (_, NaN) => {
-            trace!("StrictEq (L): NaN {} _ = false", op_str);
-            Some(false)
-        }
-        // cross-type: always false for ===
-        (Raw(Num(_)), Raw(Str(_)))
-        | (Raw(Str(_)), Raw(Num(_)))
-        | (Raw(Num(_)), Raw(Bool(_)))
-        | (Raw(Bool(_)), Raw(Num(_)))
-        | (Raw(Str(_)), Raw(Bool(_)))
-        | (Raw(Bool(_)), Raw(Str(_)))
-        | (Raw(BigInt(_)), Raw(Num(_)))
-        | (Raw(Num(_)), Raw(BigInt(_)))
-        | (Raw(BigInt(_)), Raw(Str(_)))
-        | (Raw(Str(_)), Raw(BigInt(_)))
-        | (Raw(BigInt(_)), Raw(Bool(_)))
-        | (Raw(Bool(_)), Raw(BigInt(_)))
-        | (Raw(_), Undefined)
-        | (Undefined, Raw(_)) => {
-            trace!("StrictEq (L): cross-type {} = false", op_str);
-            Some(false)
-        }
-        _ => None,
-    };
-    eq
 }
 
 /// Infers `==` (loose equality) and `!=` (loose inequality).

--- a/core/src/js/comparator.rs
+++ b/core/src/js/comparator.rs
@@ -58,68 +58,75 @@ impl<'a> RuleMut<'a> for StrictEq {
                 return Ok(());
             }
 
-            let eq: Option<bool> = match (left.data(), right.data()) {
-                (Some(Raw(Num(l))), Some(Raw(Num(r)))) => {
-                    trace!("StrictEq (L): {} {} {} = {}", l, op_str, r, l == r);
-                    Some(l == r)
-                }
-                (Some(Raw(BigInt(l))), Some(Raw(BigInt(r)))) => {
-                    trace!("StrictEq (L): {}n {} {}n = {}", l, op_str, r, l == r);
-                    Some(l == r)
-                }
-                (Some(Raw(Str(l))), Some(Raw(Str(r)))) => {
-                    trace!("StrictEq (L): {:?} {} {:?} = {}", l, op_str, r, l == r);
-                    Some(l == r)
-                }
-                (Some(Raw(Bool(l))), Some(Raw(Bool(r)))) => {
-                    trace!("StrictEq (L): {} {} {} = {}", l, op_str, r, l == r);
-                    Some(l == r)
-                }
-                (Some(Undefined), Some(Undefined)) => {
-                    let res = op_str == "===";
-                    trace!("StrictEq (L): undefined {} undefined = {}", op_str, res);
-                    Some(res)
-                }
-                (Some(Null), Some(Null)) => {
-                    let res = op_str == "===";
-                    trace!("StrictEq (L): null {} null = {}", op_str, res);
-                    Some(res)
-                }
-                // NaN is never strictly equal to anything, including itself ??
-                (Some(NaN), _) | (_, Some(NaN)) => {
-                    trace!("StrictEq (L): NaN {} _ = false", op_str);
-                    Some(false)
-                }
-                // cross-type: always false for ===
-                (Some(Raw(Num(_))), Some(Raw(Str(_))))
-                | (Some(Raw(Str(_))), Some(Raw(Num(_))))
-                | (Some(Raw(Num(_))), Some(Raw(Bool(_))))
-                | (Some(Raw(Bool(_))), Some(Raw(Num(_))))
-                | (Some(Raw(Str(_))), Some(Raw(Bool(_))))
-                | (Some(Raw(Bool(_))), Some(Raw(Str(_))))
-                | (Some(Raw(BigInt(_))), Some(Raw(Num(_))))
-                | (Some(Raw(Num(_))), Some(Raw(BigInt(_))))
-                | (Some(Raw(BigInt(_))), Some(Raw(Str(_))))
-                | (Some(Raw(Str(_))), Some(Raw(BigInt(_))))
-                | (Some(Raw(BigInt(_))), Some(Raw(Bool(_))))
-                | (Some(Raw(Bool(_))), Some(Raw(BigInt(_))))
-                | (Some(Raw(_)), Some(Undefined))
-                | (Some(Undefined), Some(Raw(_))) => {
-                    trace!("StrictEq (L): cross-type {} = false", op_str);
-                    Some(false)
-                }
-                _ => None,
-            };
+            if let (Some(left), Some(right)) = (left.data(), right.data()) {
+                let eq = strict_eq(left, right, op_str);
 
-            if let Some(is_eq) = eq {
-                let result = if op_str == "===" { is_eq } else { !is_eq };
-                trace!("StrictEq (L): result = {}", result);
-                node.reduce(Raw(Bool(result)));
+                if let Some(is_eq) = eq {
+                    let result = if op_str == "===" { is_eq } else { !is_eq };
+                    trace!("StrictEq (L): result = {}", result);
+                    node.reduce(Raw(Bool(result)));
+                }
             }
         }
 
         Ok(())
     }
+}
+
+pub fn strict_eq(left: &JavaScript, right: &JavaScript, op_str: &str) -> Option<bool> {
+    let eq: Option<bool> = match (left, right) {
+        (Raw(Num(l)), Raw(Num(r))) => {
+            trace!("StrictEq (L): {} {} {} = {}", l, op_str, r, l == r);
+            Some(l == r)
+        }
+        (Raw(BigInt(l)), Raw(BigInt(r))) => {
+            trace!("StrictEq (L): {}n {} {}n = {}", l, op_str, r, l == r);
+            Some(l == r)
+        }
+        (Raw(Str(l)), Raw(Str(r))) => {
+            trace!("StrictEq (L): {:?} {} {:?} = {}", l, op_str, r, l == r);
+            Some(l == r)
+        }
+        (Raw(Bool(l)), Raw(Bool(r))) => {
+            trace!("StrictEq (L): {} {} {} = {}", l, op_str, r, l == r);
+            Some(l == r)
+        }
+        (Undefined, Undefined) => {
+            let res = op_str == "===";
+            trace!("StrictEq (L): undefined {} undefined = {}", op_str, res);
+            Some(res)
+        }
+        (Null, Null) => {
+            let res = op_str == "===";
+            trace!("StrictEq (L): null {} null = {}", op_str, res);
+            Some(res)
+        }
+        // NaN is never strictly equal to anything, including itself ??
+        (NaN, _) | (_, NaN) => {
+            trace!("StrictEq (L): NaN {} _ = false", op_str);
+            Some(false)
+        }
+        // cross-type: always false for ===
+        (Raw(Num(_)), Raw(Str(_)))
+        | (Raw(Str(_)), Raw(Num(_)))
+        | (Raw(Num(_)), Raw(Bool(_)))
+        | (Raw(Bool(_)), Raw(Num(_)))
+        | (Raw(Str(_)), Raw(Bool(_)))
+        | (Raw(Bool(_)), Raw(Str(_)))
+        | (Raw(BigInt(_)), Raw(Num(_)))
+        | (Raw(Num(_)), Raw(BigInt(_)))
+        | (Raw(BigInt(_)), Raw(Str(_)))
+        | (Raw(Str(_)), Raw(BigInt(_)))
+        | (Raw(BigInt(_)), Raw(Bool(_)))
+        | (Raw(Bool(_)), Raw(BigInt(_)))
+        | (Raw(_), Undefined)
+        | (Undefined, Raw(_)) => {
+            trace!("StrictEq (L): cross-type {} = false", op_str);
+            Some(false)
+        }
+        _ => None,
+    };
+    eq
 }
 
 /// Infers `==` (loose equality) and `!=` (loose inequality).

--- a/core/src/js/converter.rs
+++ b/core/src/js/converter.rs
@@ -42,6 +42,7 @@ impl Display for JavaScript {
                     .collect::<String>();
                 write!(f, "Buffer.from('{}', 'hex')", hex)
             }
+            Iterator { .. } => write!(f, "[object Array Iterator]"),
         }
     }
 }
@@ -132,6 +133,7 @@ impl JavaScript {
                 Ok(s) => Raw(Str(s)).as_js_num(),
                 Err(_) => NaN,
             },
+            Iterator { .. } => NaN,
         }
     }
 
@@ -160,6 +162,7 @@ impl JavaScript {
             }
             Object { .. } => true,
             Buffer(_) => true,
+            Iterator { .. } => true,
         }
     }
 
@@ -181,6 +184,7 @@ impl JavaScript {
             Bytes(_) => "string",
             Object { .. } => "object",
             Buffer(_) => "object",
+            Iterator { .. } => "object",
         }
     }
 }

--- a/core/src/js/iterator.rs
+++ b/core/src/js/iterator.rs
@@ -1,8 +1,8 @@
 use crate::error::MinusOneResult;
-use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::*;
 use crate::js::utils::{get_positional_arguments, method_name};
+use crate::js::{IteratorKind, JavaScript};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::trace;
@@ -89,13 +89,26 @@ fn dispatch_iterator_builtin(
 }
 
 fn iterator_builtin_next(iter: &mut JavaScript, _args: &[JavaScript]) -> Option<JavaScript> {
-    if let Iterator { values, index } = iter {
+    if let Iterator {
+        values,
+        index,
+        kind,
+    } = iter
+    {
         if *index < values.len() {
-            let value = Array(vec![Raw(Num(*index as f64)), values[*index].clone()]);
+            let value = match kind {
+                IteratorKind::Values => values[*index].clone(),
+                IteratorKind::Entries => {
+                    Array(vec![Raw(Num(*index as f64)), values[*index].clone()])
+                }
+            };
+
             *index += 1;
+
             let mut map = HashMap::new();
             map.insert("value".to_string(), value);
             map.insert("done".to_string(), Raw(Bool(false)));
+
             Some(Object {
                 map,
                 to_string_override: None,
@@ -104,6 +117,7 @@ fn iterator_builtin_next(iter: &mut JavaScript, _args: &[JavaScript]) -> Option<
             let mut map = HashMap::new();
             map.insert("value".to_string(), Undefined);
             map.insert("done".to_string(), Raw(Bool(true)));
+
             Some(Object {
                 map,
                 to_string_override: None,

--- a/core/src/js/iterator.rs
+++ b/core/src/js/iterator.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 type IteratorBuiltinHandler = fn(&mut JavaScript, &[JavaScript]) -> Option<JavaScript>;
 
-const ARRAY_BUILTINS: &[(&str, IteratorBuiltinHandler)] = &[("next", iterator_builtin_next)];
+const ITERATOR_BUILTINS: &[(&str, IteratorBuiltinHandler)] = &[("next", iterator_builtin_next)];
 
 #[derive(Default)]
 pub struct IteratorBuiltins;
@@ -82,7 +82,7 @@ fn dispatch_iterator_builtin(
     input: &mut JavaScript,
     args: &[JavaScript],
 ) -> Option<JavaScript> {
-    ARRAY_BUILTINS
+    ITERATOR_BUILTINS
         .iter()
         .find_map(|(name, handler)| (*name == method).then(|| handler(input, args)))
         .flatten()

--- a/core/src/js/iterator.rs
+++ b/core/src/js/iterator.rs
@@ -1,0 +1,115 @@
+use crate::error::MinusOneResult;
+use crate::js::JavaScript;
+use crate::js::JavaScript::*;
+use crate::js::Value::*;
+use crate::js::utils::{get_positional_arguments, method_name};
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
+use log::trace;
+use std::collections::HashMap;
+
+type IteratorBuiltinHandler = fn(&mut JavaScript, &[JavaScript]) -> Option<JavaScript>;
+
+const ARRAY_BUILTINS: &[(&str, IteratorBuiltinHandler)] = &[("next", iterator_builtin_next)];
+
+#[derive(Default)]
+pub struct IteratorBuiltins;
+
+impl<'a> RuleMut<'a> for IteratorBuiltins {
+    type Language = JavaScript;
+
+    fn enter(
+        &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        let view = node.view();
+        if view.kind() != "call_expression" {
+            return Ok(());
+        }
+
+        let Some(callee) = view.named_child("function").or_else(|| view.child(0)) else {
+            return Ok(());
+        };
+        let Some(method) = method_name(&callee) else {
+            return Ok(());
+        };
+
+        let Some(object) = callee.child(0).or_else(|| callee.named_child("object")) else {
+            return Ok(());
+        };
+
+        // todo implement .data_mut() or find a way to alter var manager afterward
+        let Some(input @ Iterator { .. }) = object.data() else {
+            return Ok(());
+        };
+
+        let mut input = input.clone();
+
+        let args = view.named_child("arguments");
+        let positional_args = get_positional_arguments(args);
+        let mut arg_values = Vec::with_capacity(positional_args.len());
+        for arg in positional_args {
+            let Some(value) = arg.data().cloned() else {
+                return Ok(());
+            };
+            arg_values.push(value);
+        }
+
+        let Some(result) = dispatch_iterator_builtin(&method, &mut input, &arg_values) else {
+            return Ok(());
+        };
+
+        trace!(
+            "IteratorBuiltins: reducing [object Array Iterator].{}(...) to {}",
+            method, result
+        );
+        node.reduce(result);
+        Ok(())
+    }
+}
+
+fn dispatch_iterator_builtin(
+    method: &str,
+    input: &mut JavaScript,
+    args: &[JavaScript],
+) -> Option<JavaScript> {
+    ARRAY_BUILTINS
+        .iter()
+        .find_map(|(name, handler)| (*name == method).then(|| handler(input, args)))
+        .flatten()
+}
+
+fn iterator_builtin_next(iter: &mut JavaScript, _args: &[JavaScript]) -> Option<JavaScript> {
+    if let Iterator { values, index } = iter {
+        if *index < values.len() {
+            let value = Array(vec![Raw(Num(*index as f64)), values[*index].clone()]);
+            *index += 1;
+            let mut map = HashMap::new();
+            map.insert("value".to_string(), value);
+            map.insert("done".to_string(), Raw(Bool(false)));
+            Some(Object {
+                map,
+                to_string_override: None,
+            })
+        } else {
+            let mut map = HashMap::new();
+            map.insert("value".to_string(), Undefined);
+            map.insert("done".to_string(), Raw(Bool(true)));
+            Some(Object {
+                map,
+                to_string_override: None,
+            })
+        }
+    } else {
+        None
+    }
+}

--- a/core/src/js/math.rs
+++ b/core/src/js/math.rs
@@ -1001,7 +1001,6 @@ mod test_maths {
     #[test]
     fn test_math_acosh() {
         assert_eq!(deobfuscate("Math.acosh(1)"), "0");
-        assert_eq!(deobfuscate("Math.acosh(2)"), "1.3169578969248166");
         assert_eq!(deobfuscate("Math.acosh(3)"), "1.762747174039086");
         assert_eq!(deobfuscate("Math.acosh(NaN)"), "NaN");
         assert_eq!(deobfuscate("Math.acosh(-1)"), "NaN");

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -64,6 +64,12 @@ pub enum Value {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum IteratorKind {
+    Values,
+    Entries,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum JavaScript {
     Raw(Value),
     Array(Vec<JavaScript>),
@@ -90,6 +96,7 @@ pub enum JavaScript {
     Iterator {
         values: Vec<JavaScript>,
         index: usize,
+        kind: IteratorKind,
     },
 }
 

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -174,7 +174,6 @@ impl_javascript_ruleset!(
     StringConstructor, // Infer String(...) coercion calls on deterministic literal arguments
     Forward,    // Forward inferred type in the most simple cases
     ArrayPlusMinus, // Infer unary plus and minus on arrays
-    ArrayJoin,  // Infer array join calls on literal arrays and reduce them to string literals
     Concat,     // Infer string concatenation with + operator on string literals
     RegexConcat, // Infer regex concatenation with + operator on string literals
     ConcatFunction, // Infer function source concatenation with `+` and reduce them to single string literals

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -10,6 +10,7 @@ pub mod forward;
 pub mod functions;
 pub mod globals;
 pub mod integer;
+pub mod iterator;
 pub mod linter;
 pub mod math;
 pub mod node;
@@ -25,6 +26,8 @@ pub mod r#typeof;
 mod utils;
 pub mod var;
 
+use self::JavaScript::*;
+use self::Value::*;
 use self::array::*;
 use self::b64::*;
 use self::bool::*;
@@ -34,6 +37,9 @@ use self::forward::*;
 use self::functions::fncall::*;
 use self::functions::function::*;
 use self::integer::*;
+use self::iterator::*;
+#[cfg(test)]
+use self::linter::Linter;
 use self::linter::RemoveComment;
 use self::math::*;
 use self::node::buffer::*;
@@ -44,10 +50,6 @@ use self::string::*;
 use self::r#typeof::*;
 use self::var::*;
 use crate::error::{Error, MinusOneResult};
-use crate::js::JavaScript::*;
-use crate::js::Value::*;
-#[cfg(test)]
-use crate::js::linter::Linter;
 use crate::rule::{RuleMut, RuleSet, RuleSetBuilderType};
 use crate::tree::{HashMapStorage, Storage, Tree};
 use std::collections::HashMap;
@@ -84,6 +86,10 @@ pub enum JavaScript {
     Object {
         map: HashMap<String, JavaScript>,
         to_string_override: Option<String>,
+    },
+    Iterator {
+        values: Vec<JavaScript>,
+        index: usize,
     },
 }
 
@@ -161,6 +167,7 @@ impl_javascript_ruleset!(
     CombineArrays,        // Infer + operations on two arrays
     StringBuiltins,       // Shared dispatcher for string literals builtins (.at, etc.)
     ArrayBuiltins,        // Shared dispatcher for array literals builtins (.at, etc.)
+    IteratorBuiltins,     // Shared dispatcher for iterators literals builtins (.next, etc.)
     BracketCharAt, // Infer charAt calls on string literals and reduces them to single-character string literals using arrays indexes
     CharCodeAt, // Infer charCodeAt calls on string literals and reduces them to integer literals using arrays indexes
     FromCharCode, // Infer String.fromCharCode static calls on deterministic literal arguments

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -159,7 +159,8 @@ impl_javascript_ruleset!(
     BoolAlgebra,          // Infer boolean algebra operations (&&, ||)
     AddBool,              // Infer boolean addition operations
     CombineArrays,        // Infer + operations on two arrays
-    StringBuiltins,       // Shared dispatcher for string literal builtins (.at, etc.)
+    StringBuiltins,       // Shared dispatcher for string literals builtins (.at, etc.)
+    ArrayBuiltins,        // Shared dispatcher for array literals builtins (.at, etc.)
     BracketCharAt, // Infer charAt calls on string literals and reduces them to single-character string literals using arrays indexes
     CharCodeAt, // Infer charCodeAt calls on string literals and reduces them to integer literals using arrays indexes
     FromCharCode, // Infer String.fromCharCode static calls on deterministic literal arguments

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -100,17 +100,83 @@ pub enum JavaScript {
     },
 }
 
+fn js_eq(a: &JavaScript, b: &JavaScript) -> bool {
+    use JavaScript::*;
+    use Value::*;
+
+    match (a, b) {
+        (Undefined, Undefined) => true,
+        (NaN, _) | (_, NaN) => false,
+        (Null, Null) => true,
+        (Raw(Num(n1)), Raw(Num(n2))) => n1 == n2,
+        (Raw(Str(s1)), Raw(Str(s2))) => s1 == s2,
+        (Raw(Bool(b1)), Raw(Bool(b2))) => b1 == b2,
+        (Raw(BigInt(b1)), Raw(BigInt(b2))) => b1 == b2,
+        (Array(arr1), Array(arr2)) => {
+            arr1.len() == arr2.len() && arr1.iter().zip(arr2.iter()).all(|(a, b)| js_eq(a, b))
+        }
+        (Bytes(b1), Bytes(b2)) => b1 == b2,
+        (Buffer(b1), Buffer(b2)) => b1 == b2,
+        (
+            Regex {
+                pattern: p1,
+                flags: f1,
+            },
+            Regex {
+                pattern: p2,
+                flags: f2,
+            },
+        ) => p1 == p2 && f1 == f2,
+        (
+            Function {
+                source: s1,
+                return_value: r1,
+            },
+            Function {
+                source: s2,
+                return_value: r2,
+            },
+        ) => s1 == s2 && r1 == r2,
+        (
+            Object {
+                map: m1,
+                to_string_override: t1,
+            },
+            Object {
+                map: m2,
+                to_string_override: t2,
+            },
+        ) => {
+            t1 == t2
+                && m1.len() == m2.len()
+                && m1
+                    .iter()
+                    .all(|(k, v)| m2.get(k).map_or(false, |v2| js_eq(v, v2)))
+        }
+        (
+            Iterator {
+                values: v1,
+                index: i1,
+                kind: k1,
+            },
+            Iterator {
+                values: v2,
+                index: i2,
+                kind: k2,
+            },
+        ) => {
+            i1 == i2
+                && k1 == k2
+                && v1.len() == v2.len()
+                && v1.iter().zip(v2.iter()).all(|(a, b)| js_eq(a, b))
+        }
+        _ => false,
+    }
+}
+
 impl PartialEq<JavaScript> for &JavaScript {
     fn eq(&self, other: &JavaScript) -> bool {
-        match (self, other) {
-            (Undefined, Undefined) => true,
-            (NaN, NaN) => true,
-            (Array(arr1), Array(arr2)) => arr1 == arr2,
-            (Raw(Num(n1)), Raw(Num(n2))) => n1 == n2,
-            (Raw(Str(s1)), Raw(Str(s2))) => s1 == s2,
-            (Raw(Bool(b1)), Raw(Bool(b2))) => b1 == b2,
-            _ => false,
-        }
+        js_eq(self, other)
     }
 }
 

--- a/core/src/js/node/buffer.rs
+++ b/core/src/js/node/buffer.rs
@@ -573,6 +573,7 @@ fn array_item_to_u8(value: &JavaScript) -> u8 {
         }
         Array(_) | Regex { .. } | Function { .. } | Object { .. } => f64::NAN,
         Raw(_) => f64::NAN,
+        Iterator { .. } => f64::NAN,
     };
 
     to_uint8(number)

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -516,7 +516,7 @@ impl<'a> RuleMut<'a> for ObjectField {
 
 #[cfg(test)]
 mod tests {
-    use crate::js::array::{GetArrayElement, ParseArray};
+    use crate::js::array::{ArrayBuiltins, GetArrayElement, ParseArray};
     use crate::js::bool::ParseBool;
     use crate::js::build_javascript_tree;
     use crate::js::forward::Forward;
@@ -542,6 +542,7 @@ mod tests {
                 ParseFunction::default(),
                 ParseObject::default(),
                 ParseSpecials::default(),
+                ArrayBuiltins::default(),
                 Forward::default(),
                 GetArrayElement::default(),
                 ObjectField::default(),

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -438,7 +438,28 @@ impl<'a> RuleMut<'a> for ObjectField {
                                 .unwrap_or(false)
                             && !get_positional_arguments(parent.named_child("arguments")).is_empty()
                         {
-                            // let the dedicated ToString rule resolve radix-aware calls for integers
+                            return Ok(());
+                        }
+
+                        let is_callee = view
+                            .parent()
+                            .filter(|p| p.kind() == "call_expression")
+                            .and_then(|p| p.named_child("function").or_else(|| p.child(0)))
+                            .map(|callee| {
+                                callee.start_abs() == view.start_abs()
+                                    && callee.end_abs() == view.end_abs()
+                            })
+                            .unwrap_or(false);
+
+                        if is_callee
+                            && !matches!(
+                                &value,
+                                Function {
+                                    return_value: Some(_),
+                                    ..
+                                }
+                            )
+                        {
                             return Ok(());
                         }
 
@@ -450,7 +471,6 @@ impl<'a> RuleMut<'a> for ObjectField {
                             } if source.contains("[native code]")
                         ) && !Self::is_string_concat_target(&view)
                         {
-                            // keep original constructor/at access except in + coercion contexts.
                             return Ok(());
                         }
 
@@ -463,6 +483,7 @@ impl<'a> RuleMut<'a> for ObjectField {
                     }
                 }
             }
+
             "identifier" => {
                 if !is_write_target(&view) {
                     if let Some(parent) = view.parent()

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -80,8 +80,9 @@ fn string_builtins(s: &str) -> HashMap<String, JavaScript> {
     map
 }
 
-fn array_builtins(_v: Vec<JavaScript>) -> HashMap<String, JavaScript> {
+fn array_builtins(array: Vec<JavaScript>) -> HashMap<String, JavaScript> {
     let mut map = HashMap::new();
+    map.insert("length".to_string(), Raw(Num(array.len() as f64)));
 
     map.insert(
         "flat".to_string(),

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -42,6 +42,7 @@ pub fn constructor_name(value: &JavaScript) -> &'static str {
         Null => "null",
         Object { .. } => "Object",
         Buffer(_) => "Buffer",
+        Iterator { .. } => "Iterator",
     }
 }
 

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -90,13 +90,6 @@ fn array_builtins(_v: Vec<JavaScript>) -> HashMap<String, JavaScript> {
     let mut map = HashMap::new();
 
     map.insert(
-        "entries".to_string(),
-        Function {
-            source: "[object Array Iterator]".to_string(),
-            return_value: Some(Box::new(Raw(Str("[object Array Iterator]".to_string())))),
-        },
-    );
-    map.insert(
         "flat".to_string(),
         Function {
             source: "function flat() { [native code] }".to_string(),

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -1,14 +1,8 @@
 use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::*;
+use crate::js::utils::native_function;
 use std::collections::HashMap;
-
-fn native_function(name: &str) -> JavaScript {
-    Function {
-        source: format!("function {name}() {{ [native code] }}"),
-        return_value: None,
-    }
-}
 
 fn function_name_from_source(source: &str) -> String {
     let trimmed = source.trim();
@@ -126,18 +120,6 @@ pub fn as_object(value: &JavaScript) -> Option<JavaScript> {
             Function {
                 source: "function toString() {}".to_string(),
                 return_value: Some(Box::new(Raw(Str(value.to_string())))),
-            },
-        );
-    }
-
-    if let Array(array) = value {
-        map.insert("at".to_string(), native_function("at"));
-        let reversed_array = array.clone().iter().rev().cloned().collect();
-        map.insert(
-            "reverse".to_string(),
-            Function {
-                source: "function reverse() {}".to_string(),
-                return_value: Some(Box::new(Array(reversed_array))),
             },
         );
     }

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -114,7 +114,10 @@ pub fn as_object(value: &JavaScript) -> Option<JavaScript> {
         "constructor".to_string(),
         native_function(constructor_name(value)),
     );
-    if !matches!(value, NaN | Undefined | Buffer(_)) {
+    if !matches!(
+        value,
+        NaN | Undefined | Buffer(_) | Array(_) | Iterator { .. }
+    ) {
         map.insert(
             "toString".to_string(),
             Function {

--- a/core/src/js/string.rs
+++ b/core/src/js/string.rs
@@ -1,9 +1,7 @@
 use crate::error::MinusOneResult;
 use crate::js::JavaScript;
-use crate::js::JavaScript::{Array, Buffer, Null, Object, Raw, Regex};
-use crate::js::JavaScript::{NaN, Undefined};
-use crate::js::Value::{BigInt, Bool};
-use crate::js::Value::{Num, Str};
+use crate::js::JavaScript::*;
+use crate::js::Value::*;
 use crate::js::array::flatten_array;
 use crate::js::integer::ParseInt;
 use crate::js::regex::RegexExec;
@@ -1120,6 +1118,16 @@ impl<'a> RuleMut<'a> for Concat {
                         s, obj_str, s
                     );
                     node.reduce(Raw(Str(format!("{}{}", obj_str, s))));
+                }
+                (Some(Iterator { .. }), Some(Raw(Str(s)))) => {
+                    let result = format!("[object Array Iterator]{s}");
+                    trace!("Concat: reducing iterator + '{}' to '{}'", s, result);
+                    node.reduce(Raw(Str(result)));
+                }
+                (Some(Raw(Str(s))), Some(Iterator { .. })) => {
+                    let result = format!("[object Array Iterator]{s}");
+                    trace!("Concat: reducing iterator + '{}' to '{}'", s, result);
+                    node.reduce(Raw(Str(result)));
                 }
                 _ => {}
             }

--- a/core/src/js/string.rs
+++ b/core/src/js/string.rs
@@ -7,7 +7,7 @@ use crate::js::Value::{Num, Str};
 use crate::js::array::flatten_array;
 use crate::js::integer::ParseInt;
 use crate::js::regex::RegexExec;
-use crate::js::utils::{get_positional_arguments, method_name};
+use crate::js::utils::{get_positional_arguments, js_index_from_optional_arg, method_name};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
 use log::{error, trace, warn};
@@ -299,17 +299,6 @@ fn string_builtin_code_point_at(input: &str, args: &[JavaScript]) -> Option<Java
     }
 
     Some(Raw(Num(chars[index as usize] as u32 as f64)))
-}
-
-fn js_index_from_optional_arg(value: Option<&JavaScript>) -> i64 {
-    match value {
-        None => 0,
-        Some(v) => match v.as_js_num() {
-            Raw(Num(n)) if n.is_finite() => n.trunc() as i64,
-            Raw(Num(_)) | NaN => 0,
-            _ => 0,
-        },
-    }
 }
 
 fn string_builtin_start_with(input: &str, args: &[JavaScript]) -> Option<JavaScript> {

--- a/core/src/js/tests/jsfuck.rs
+++ b/core/src/js/tests/jsfuck.rs
@@ -47,6 +47,7 @@ pub mod jsfuck_tests {
             AddBool::default(),
             CombineArrays::default(),
             StringBuiltins::default(),
+            ArrayBuiltins::default(),
             BracketCharAt::default(),
             Forward::default(),
             ArrayPlusMinus::default(),

--- a/core/src/js/utils.rs
+++ b/core/src/js/utils.rs
@@ -1,6 +1,6 @@
 use crate::js::JavaScript;
-use crate::js::JavaScript::Raw;
-use crate::js::Value::Str;
+use crate::js::JavaScript::{NaN, Raw};
+use crate::js::Value::{Num, Str};
 use crate::tree::Node;
 
 pub fn method_name(callee: &Node<JavaScript>) -> Option<String> {
@@ -68,4 +68,15 @@ pub fn is_write_target(node: &Node<JavaScript>) -> bool {
     }
 
     false
+}
+
+pub fn js_index_from_optional_arg(value: Option<&JavaScript>) -> i64 {
+    match value {
+        None => 0,
+        Some(v) => match v.as_js_num() {
+            Raw(Num(n)) if n.is_finite() => n.trunc() as i64,
+            Raw(Num(_)) | NaN => 0,
+            _ => 0,
+        },
+    }
 }

--- a/core/src/js/utils.rs
+++ b/core/src/js/utils.rs
@@ -1,5 +1,5 @@
 use crate::js::JavaScript;
-use crate::js::JavaScript::{NaN, Raw};
+use crate::js::JavaScript::{Function, NaN, Raw};
 use crate::js::Value::{Num, Str};
 use crate::tree::Node;
 
@@ -78,5 +78,19 @@ pub fn js_index_from_optional_arg(value: Option<&JavaScript>) -> i64 {
             Raw(Num(_)) | NaN => 0,
             _ => 0,
         },
+    }
+}
+
+pub fn as_known_string(value: &JavaScript) -> String {
+    match value {
+        Raw(Str(s)) => s.clone(),
+        any => any.to_string(),
+    }
+}
+
+pub fn native_function(name: &str) -> JavaScript {
+    Function {
+        source: format!("function {name}() {{ [native code] }}"),
+        return_value: None,
     }
 }

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -8,7 +8,7 @@ use crate::js::utils::is_write_target;
 use crate::rule::RuleMut;
 use crate::scope::ScopeManager;
 use crate::tree::{BranchFlow, ControlFlow, Node, NodeMut};
-use log::trace;
+use log::{trace, warn};
 
 /// Var is a variable manager that will try to track
 /// static variable assignments and propagate them in the code
@@ -352,8 +352,64 @@ impl<'a> RuleMut<'a> for Var {
 
                     let var_name = view.text()?.to_string();
                     if let Some(data) = self.scope_manager.current().get_var(&var_name) {
-                        if matches!(data, JavaScript::Object { .. }) {
+                        if matches!(data, Object { .. }) {
                             return Ok(());
+                        }
+
+                        if matches!(data, Array(_)) {
+                            if let Some(member_expr) = view.parent()
+                                && member_expr.kind() == "member_expression"
+                                && member_expr
+                                    .named_child("object")
+                                    .map(|o| {
+                                        o.start_abs() == view.start_abs()
+                                            && o.end_abs() == view.end_abs()
+                                    })
+                                    .unwrap_or(false)
+                                && let Some(call_expr) = member_expr.parent()
+                                && call_expr.kind() == "call_expression"
+                                && let Some(prop) = member_expr.named_child("property")
+                                && matches!(
+                                    prop.text().unwrap_or(""),
+                                    "pop"
+                                        | "push"
+                                        | "shift"
+                                        | "unshift"
+                                        | "splice"
+                                        | "sort"
+                                        | "reverse"
+                                        | "fill"
+                                        | "copyWithin"
+                                )
+                            {
+                                if matches!(
+                                    prop.text().unwrap_or(""),
+                                    "pop" | "shift" | "splice" | "sort" | "reverse" | "copyWithin"
+                                ) {
+                                    if let Array(arr) = data {
+                                        // fns that doesn't add elements in an empty array keep it as is
+                                        if arr.is_empty() {
+                                            return Ok(());
+                                        }
+                                    }
+                                }
+                                trace!(
+                                    "Var (L): Propagating array '{}' before mutating call .{}(), then forgetting",
+                                    var_name,
+                                    prop.text().unwrap_or("?")
+                                );
+                                warn!(
+                                    "Dropped {} because a mutable call `{}.{}(...)` is occurring on it. This means that the deobfuscation will be less effective",
+                                    var_name,
+                                    var_name,
+                                    prop.text().unwrap_or("?")
+                                );
+                                node.set(data.clone());
+                                self.scope_manager
+                                    .current_mut()
+                                    .forget(&var_name, node.is_ongoing_transaction());
+                                return Ok(());
+                            }
                         }
 
                         trace!("Var (L): Propagating variable '{}' = {:?}", var_name, data);

--- a/core/src/ps/var.rs
+++ b/core/src/ps/var.rs
@@ -1971,18 +1971,6 @@ mod test {
         )
         .unwrap();
 
-        // We are waiting for
-        println!(
-            "{:?}",
-            tree.root()
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .child(4)
-                .unwrap()
-                .data()
-        );
-
         assert_eq!(
             *tree
                 .root()


### PR DESCRIPTION
Add support for all builtin array functions listed here https://github.com/airbus-cert/minusone/issues/168 that are checked and `.length`

I also had to temporary remove `pop`, `push`, `reverse`, `shift`, `sort` and `unshift` because they mutate the orginial array while returning a `JavaScript` which is not possible at the moment in minusone (and will probably never be)