### PR TITLE
Small jsfuck fix

### DIFF
--- a/core/src/js/array.rs
+++ b/core/src/js/array.rs
@@ -890,11 +890,7 @@ impl<'a> RuleMut<'a> for CombineArrays {
                     let combined = format!(
                         "{}{}",
                         flatten_array(left_values, None),
-                        match javascript {
-                            Raw(Str(s)) => s.clone(),
-                            Array(a) => flatten_array(a, None),
-                            any => any.to_string(),
-                        }
+                        js_to_string_value(javascript)
                     );
                     trace!(
                         "CombineArrays (L): combining array and non-raw => left: {:?}, right: {:?} => '{}'",
@@ -905,11 +901,7 @@ impl<'a> RuleMut<'a> for CombineArrays {
                 (Some(javascript), "+", Some(Array(right_values))) => {
                     let combined = format!(
                         "{}{}",
-                        match javascript {
-                            Raw(Str(s)) => s.clone(),
-                            Array(a) => flatten_array(a, None),
-                            any => any.to_string(),
-                        },
+                        js_to_string_value(javascript),
                         flatten_array(right_values, None)
                     );
                     trace!(

--- a/core/src/js/functions/fncall.rs
+++ b/core/src/js/functions/fncall.rs
@@ -1,8 +1,9 @@
 use crate::error::MinusOneResult;
 use crate::js::JavaScript;
+use crate::js::JavaScript::Undefined;
 use crate::js::Value::{Num, Str};
 use crate::js::functions::function::function_value_from_node;
-use crate::js::utils::{get_positional_arguments, method_name};
+use crate::js::utils::{get_positional_arguments, js_to_string_value, method_name};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::trace;
@@ -1048,6 +1049,25 @@ impl<'a> RuleMut<'a> for FnCall {
                             );
                             node.reduce(return_value.as_ref().clone());
                         }
+                    } else if method_name(&func_node).as_deref() == Some("fontcolor")
+                        && let Some(object_node) = func_node.named_child("object")
+                        && let Some(JavaScript::Raw(Str(base))) = object_node.data()
+                    {
+                        let color = js_to_string_value(
+                            get_positional_arguments(view.named_child("arguments"))
+                                .first()
+                                .and_then(|arg| arg.data())
+                                .unwrap_or(&Undefined),
+                        )
+                        .replace('"', "&quot;");
+
+                        trace!(
+                            "FnCall (L): Resolving fontcolor call on {:?} with color {:?}",
+                            base, color
+                        );
+                        node.reduce(JavaScript::Raw(Str(format!(
+                            "<font color=\"{color}\">{base}</font>"
+                        ))));
                     } else if let Some(return_value) =
                         func_node.data().and_then(Self::function_return_from_value)
                     {
@@ -1141,6 +1161,22 @@ mod tests {
         assert_eq!(
             deobfuscate("function test() { return 'hello'; } console.log(test());"),
             "function test() { return 'hello'; } console.log('hello');"
+        );
+    }
+
+    #[test]
+    fn test_fncall_fontcolor_with_arg() {
+        assert_eq!(
+            deobfuscate("console.log('minusone'.fontcolor('red'));"),
+            "console.log('<font color=\"red\">minusone</font>');"
+        );
+    }
+
+    #[test]
+    fn test_fncall_fontcolor_escapes_quote_in_arg() {
+        assert_eq!(
+            deobfuscate("console.log(''.fontcolor('0false\"'));"),
+            "console.log('<font color=\"0false&quot;\"></font>');"
         );
     }
 

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -485,8 +485,10 @@ impl<'a> RuleMut<'a> for ObjectField {
                     if let Some(base) = base
                         && let Some(value) = Self::get_by_path(&base, &access.keys)
                     {
-                        if access.keys.last().map(|k| k.as_str()) == Some("toString")
-                            && let Some(parent) = view.parent()
+                        if matches!(
+                            access.keys.last().map(|k| k.as_str()),
+                            Some("toString") | Some("fontcolor")
+                        ) && let Some(parent) = view.parent()
                             && parent.kind() == "call_expression"
                             && parent
                                 .named_child("function")

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -1,8 +1,7 @@
 use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::*;
-use crate::js::array::flatten_array;
-use crate::js::utils::native_function;
+use crate::js::utils::{js_to_string_value, native_function};
 use log::trace;
 use std::collections::HashMap;
 
@@ -131,11 +130,7 @@ pub fn as_object(value: &JavaScript) -> Option<JavaScript> {
             "toString".to_string(),
             Function {
                 source: "function toString() {}".to_string(),
-                return_value: Some(Box::new(Raw(Str(match value {
-                    Raw(Str(s)) => s.clone(),
-                    Array(a) => flatten_array(a, None),
-                    any => any.to_string(),
-                })))),
+                return_value: Some(Box::new(Raw(Str(js_to_string_value(value))))),
             },
         );
     }

--- a/core/src/js/string.rs
+++ b/core/src/js/string.rs
@@ -6,7 +6,9 @@ use crate::js::array::flatten_array;
 use crate::js::integer::ParseInt;
 use crate::js::objects::objectify::as_object;
 use crate::js::regex::RegexExec;
-use crate::js::utils::{get_positional_arguments, js_index_from_optional_arg, method_name};
+use crate::js::utils::{
+    get_positional_arguments, js_index_from_optional_arg, js_to_string_value, method_name,
+};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, Node, NodeMut};
 use log::{error, trace, warn};
@@ -369,11 +371,7 @@ fn string_builtin_code_point_at(input: &str, args: &[JavaScript]) -> Option<Java
 fn string_builtin_concat(input: &str, args: &[JavaScript]) -> Option<JavaScript> {
     let mut result = input.to_string();
     for arg in args {
-        let arg = match arg {
-            Raw(Str(s)) => s.clone(),
-            Array(a) => flatten_array(a, None),
-            any => any.to_string(),
-        };
+        let arg = js_to_string_value(arg);
         result.push_str(&arg);
     }
     Some(Raw(Str(result)))
@@ -384,11 +382,7 @@ fn string_builtin_start_with(input: &str, args: &[JavaScript]) -> Option<JavaScr
         return Some(Raw(Bool(false)));
     }
 
-    let to_find = match args.first()? {
-        Raw(Str(s)) => s.clone(),
-        Array(a) => flatten_array(a, None),
-        any => any.to_string(),
-    };
+    let to_find = js_to_string_value(args.first()?);
 
     Some(Raw(Bool(input.starts_with(&to_find))))
 }
@@ -398,12 +392,7 @@ fn string_builtin_end_with(input: &str, args: &[JavaScript]) -> Option<JavaScrip
         return Some(Raw(Bool(false)));
     }
 
-    let to_find = match args.first()? {
-        Raw(Str(s)) => s.clone(),
-        Array(a) => flatten_array(a, None),
-        any => any.to_string(),
-    };
-
+    let to_find = js_to_string_value(args.first()?);
     Some(Raw(Bool(input.ends_with(&to_find))))
 }
 
@@ -412,12 +401,7 @@ fn string_builtin_includes(input: &str, args: &[JavaScript]) -> Option<JavaScrip
         return Some(Raw(Bool(false)));
     }
 
-    let to_find = match args.first()? {
-        Raw(Str(s)) => s.clone(),
-        Array(a) => flatten_array(a, None),
-        any => any.to_string(),
-    };
-
+    let to_find = js_to_string_value(args.first()?);
     Some(Raw(Bool(input.contains(&to_find))))
 }
 
@@ -426,12 +410,7 @@ fn string_builtin_index_of(input: &str, args: &[JavaScript]) -> Option<JavaScrip
         return Some(Raw(Num(-1.0)));
     }
 
-    let to_find = match args.first()? {
-        Raw(Str(s)) => s.clone(),
-        Array(a) => flatten_array(a, None),
-        any => any.to_string(),
-    };
-
+    let to_find = js_to_string_value(args.first()?);
     Some(Raw(Num(input
         .find(&to_find)
         .map(|i| i as f64)
@@ -443,12 +422,7 @@ fn string_builtin_last_index_of(input: &str, args: &[JavaScript]) -> Option<Java
         return Some(Raw(Num(-1.0)));
     }
 
-    let to_find = match args.first()? {
-        Raw(Str(s)) => s.clone(),
-        Array(a) => flatten_array(a, None),
-        any => any.to_string(),
-    };
-
+    let to_find = js_to_string_value(args.first()?);
     Some(Raw(Num(input
         .rfind(&to_find)
         .map(|i| i as f64)

--- a/core/src/js/utils.rs
+++ b/core/src/js/utils.rs
@@ -1,6 +1,7 @@
 use crate::js::JavaScript;
-use crate::js::JavaScript::{Function, NaN, Raw};
+use crate::js::JavaScript::{Array, Function, NaN, Raw};
 use crate::js::Value::{Num, Str};
+use crate::js::array::flatten_array;
 use crate::tree::Node;
 
 /// see [this](https://stackoverflow.com/a/63713987)
@@ -170,5 +171,13 @@ pub fn native_function(name: &str) -> JavaScript {
     Function {
         source: format!("function {name}() {{ [native code] }}"),
         return_value: None,
+    }
+}
+
+pub fn js_to_string_value(value: &JavaScript) -> String {
+    match value {
+        Raw(Str(s)) => s.clone(),
+        Array(a) => flatten_array(a, None),
+        any => any.to_string(),
     }
 }


### PR DESCRIPTION
This PR fixes jsfuck `q` and `;` extracted from the `fontcolor()` function which replaces `"` by `&quot;`