### PR TITLE
Added support for `[System.Text.Encoding]` and added `Bytes` type

### DIFF
--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -61,4 +61,6 @@ mod impl_init {
     impl_init!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL);
     impl_init!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM);
     impl_init!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN);
+    impl_init!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO);
+    impl_init!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP);
 }

--- a/core/src/ps/encoding.rs
+++ b/core/src/ps/encoding.rs
@@ -1,0 +1,745 @@
+use crate::error::MinusOneResult;
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Bytes, Raw, Type};
+use crate::ps::Value::{Num, Str};
+use crate::ps::tool::StringTool;
+use crate::ps::utils::bytes::*;
+use crate::ps::utils::string::*;
+use crate::rule::RuleMut;
+use crate::tree::{ControlFlow, NodeMut};
+use log::trace;
+
+fn is_encoding_tag(typename: &str) -> bool {
+    matches!(
+        typename,
+        "text.encoding.ascii"
+            | "text.encoding.utf8"
+            | "text.encoding.unicode"
+            | "text.encoding.bigendianunicode"
+            | "text.encoding.utf32"
+            | "text.encoding.latin1"
+            | "text.encoding.default"
+    )
+}
+
+fn static_property_tag(name: &str) -> Option<&'static str> {
+    match name {
+        "ascii" => Some("ascii"),
+        "utf8" => Some("utf8"),
+        "unicode" => Some("unicode"),
+        "bigendianunicode" => Some("bigendianunicode"),
+        "utf32" => Some("utf32"),
+        "latin1" => Some("latin1"),
+        // `Default` is the system ANSI code page on Windows PowerShell but UTF-8 on
+        // PowerShell Core, so it's only resolved as a tag here; decode()/encode() below
+        // only fold it when the payload is pure ASCII, where every runtime agrees.
+        "default" => Some("default"),
+        _ => None,
+    }
+}
+
+fn constructor_tag(typename: &str) -> Option<&'static str> {
+    match typename {
+        "system.text.asciiencoding" | "text.asciiencoding" => Some("ascii"),
+        "system.text.utf8encoding" | "text.utf8encoding" => Some("utf8"),
+        "system.text.unicodeencoding" | "text.unicodeencoding" => Some("unicode"),
+        "system.text.utf32encoding" | "text.utf32encoding" => Some("utf32"),
+        _ => None,
+    }
+}
+
+/// This rule resolves what concrete encoding a `[System.Text.Encoding]`-typed expression refers
+/// to, from any of the ways PowerShell obfuscators reach one:
+///
+/// - a static property: `[System.Text.Encoding]::UTF8`
+/// - `[System.Text.Encoding]::GetEncoding('utf-8')` / `GetEncoding(65001)`
+/// - a parameterless constructor: `[System.Text.UTF8Encoding]::new()`, `New-Object System.Text.UTF8Encoding`
+///
+/// The resolved value is one of the internal `text.encoding.*` type tags, later consumed by
+/// [`EncodingGetString`] and [`EncodingGetBytes`].
+#[derive(Default)]
+pub struct EncodingType;
+
+impl<'a> RuleMut<'a> for EncodingType {
+    type Language = Powershell;
+
+    fn enter(
+        &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        let view = node.view();
+        if view.kind() == "member_access"
+            && let (Some(type_lit), Some(op), Some(member_name)) =
+                (view.child(0), view.child(1), view.child(2))
+        {
+            match (
+                type_lit.data(),
+                op.text()?,
+                &member_name.text()?.to_string(),
+                member_name.data(),
+            ) {
+                (Some(Type(typename)), "::", m, _)
+                | (Some(Type(typename)), "::", _, Some(Raw(Str(m))))
+                    if (typename == "system.text.encoding" || typename == "text.encoding")
+                        && static_property_tag(&m.clone().normalize()).is_some() =>
+                {
+                    let tag = static_property_tag(&m.clone().normalize()).unwrap();
+                    trace!("EncodingType (L): Setting node with encoding type: {}", tag);
+                    node.set(Type(format!("text.encoding.{}", tag)));
+                }
+                _ => (),
+            }
+        } else if view.kind() == "invokation_expression"
+            && let (Some(type_node), Some(op), Some(member_name), Some(args_list)) =
+                (view.child(0), view.child(1), view.child(2), view.child(3))
+        {
+            match (
+                type_node.data(),
+                op.text()?,
+                &member_name.text()?.to_string(),
+                member_name.data(),
+            ) {
+                (Some(Type(typename)), "::", m, _)
+                | (Some(Type(typename)), "::", _, Some(Raw(Str(m))))
+                    if (typename == "system.text.encoding" || typename == "text.encoding")
+                        && m.clone().normalize() == "getencoding" =>
+                {
+                    if let Some(argument_expression_list) =
+                        args_list.named_child("argument_expression_list")
+                        && let Some(arg_1) = argument_expression_list.child(0)
+                    {
+                        let tag = match arg_1.data() {
+                            Some(Raw(Str(s))) => encoding_name_tag(&s.to_lowercase()),
+                            Some(Raw(Num(n))) => encoding_codepage_tag(*n),
+                            _ => None,
+                        };
+                        if let Some(tag) = tag {
+                            trace!(
+                                "EncodingType (L): Setting node with GetEncoding type: {}",
+                                tag
+                            );
+                            node.set(Type(format!("text.encoding.{}", tag)));
+                        }
+                    }
+                }
+                (Some(Type(typename)), "::", m, _)
+                | (Some(Type(typename)), "::", _, Some(Raw(Str(m))))
+                    if m.clone().normalize() == "new"
+                        && constructor_tag(typename).is_some()
+                        && args_list.named_child("argument_expression_list").is_none() =>
+                {
+                    let tag = constructor_tag(typename).unwrap();
+                    trace!(
+                        "EncodingType (L): Setting node with constructor type: {}",
+                        tag
+                    );
+                    node.set(Type(format!("text.encoding.{}", tag)));
+                }
+                _ => (),
+            }
+        } else if view.kind() == "command"
+            && let (Some(command_name), Some(command_elements)) = (
+                view.named_child("command_name"),
+                view.named_child("command_elements"),
+            )
+            && command_name
+                .text()
+                .is_ok_and(|name| name.to_lowercase() == "new-object")
+        {
+            let shape_ok = match command_elements.child_count() {
+                2 => true,
+                4 => command_elements
+                    .child(1)
+                    .is_some_and(|c| c.kind() == "command_parameter"),
+                _ => false,
+            };
+            if shape_ok
+                && let Some(last) = command_elements.child(command_elements.child_count() - 1)
+                && last.kind() == "generic_token"
+                && let Ok(typename) = last.text()
+                && let Some(tag) = constructor_tag(&typename.to_lowercase())
+            {
+                trace!(
+                    "EncodingType (L): Setting node with New-Object constructor type: {}",
+                    tag
+                );
+                node.set(Type(format!("text.encoding.{}", tag)));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// This rule infers `GetString(byte[])` calls on a resolved [`EncodingType`], decoding the byte
+/// array into a string.
+///
+/// # Example
+/// ```
+/// use minusone::ps::build_powershell_tree;
+/// use minusone::ps::forward::Forward;
+/// use minusone::ps::linter::Linter;
+/// use minusone::ps::typing::ParseType;
+/// use minusone::ps::integer::ParseInt;
+/// use minusone::ps::array::{ComputeArrayExpr, ParseArrayLiteral};
+/// use minusone::ps::encoding::{EncodingType, EncodingGetString};
+///
+/// let mut tree = build_powershell_tree("[System.Text.Encoding]::UTF8.GetString(@(102, 111, 111))").unwrap();
+/// tree.apply_mut(&mut (
+///     Forward::default(),
+///     ParseType::default(),
+///     EncodingType::default(),
+///     ParseInt::default(),
+///     ParseArrayLiteral::default(),
+///     ComputeArrayExpr::default(),
+///     EncodingGetString::default(),
+/// )).unwrap();
+///
+/// let mut ps_litter_view = Linter::default();
+/// tree.apply(&mut ps_litter_view).unwrap();
+///
+/// assert_eq!(ps_litter_view.output, "\"foo\"");
+/// ```
+#[derive(Default)]
+pub struct EncodingGetString;
+
+impl<'a> RuleMut<'a> for EncodingGetString {
+    type Language = Powershell;
+
+    fn enter(
+        &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        let view = node.view();
+        if view.kind() == "member_access"
+            && let (Some(type_lit), Some(op), Some(member_name)) =
+                (view.child(0), view.child(1), view.child(2))
+        {
+            match (
+                type_lit.data(),
+                op.text()?,
+                &member_name.text()?.to_string(),
+                member_name.data(),
+            ) {
+                (Some(Type(typename)), ".", m, _)
+                | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
+                    if is_encoding_tag(typename) && m.clone().normalize() == "getstring" =>
+                {
+                    let function_typename = format!("{}.getstring", typename);
+                    trace!(
+                        "EncodingGetString (L): Setting node with getstring type: {:?}",
+                        function_typename
+                    );
+                    node.set(Type(function_typename));
+                }
+                _ => (),
+            }
+        } else if view.kind() == "invokation_expression"
+            && let (Some(type_node), Some(op), Some(member_name), Some(args_list)) =
+                (view.child(0), view.child(1), view.child(2), view.child(3))
+        {
+            match (
+                type_node.data(),
+                op.text()?,
+                &member_name.text()?.to_string(),
+                member_name.data(),
+            ) {
+                (Some(Type(typename)), ".", m, _)
+                | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
+                    if (is_encoding_tag(typename) && m.clone().normalize() == "getstring")
+                        || (typename.ends_with(".getstring")
+                            && m.clone().normalize() == "invoke") =>
+                {
+                    let tag = typename
+                        .strip_prefix("text.encoding.")
+                        .and_then(|t| t.strip_suffix(".getstring").or(Some(t)))
+                        .unwrap_or(typename);
+
+                    if let Some(argument_expression_list) =
+                        args_list.named_child("argument_expression_list")
+                        && let Some(arg_1) = argument_expression_list.child(0)
+                        && let Some(data) = arg_1.data()
+                        && let Some(bytes) = bytes_from_data(data)
+                        && let Some(s) = decode(tag, &bytes)
+                    {
+                        trace!(
+                            "EncodingGetString (L): Setting node with decoded string: {:?}",
+                            s
+                        );
+                        node.set(Raw(Str(s)));
+                    }
+                }
+                _ => (),
+            }
+        }
+        Ok(())
+    }
+}
+
+/// This rule infers `GetBytes(string)` calls on a resolved [`EncodingType`], encoding the string
+/// into a [`Powershell::Bytes`], rendered by the [`crate::ps::linter::Linter`] as a `@(...)`
+/// array literal.
+///
+/// # Example
+/// ```
+/// use minusone::ps::build_powershell_tree;
+/// use minusone::ps::forward::Forward;
+/// use minusone::ps::linter::Linter;
+/// use minusone::ps::typing::ParseType;
+/// use minusone::ps::string::ParseString;
+/// use minusone::ps::encoding::{EncodingType, EncodingGetBytes};
+///
+/// let mut tree = build_powershell_tree("[System.Text.Encoding]::UTF8.GetBytes('foo')").unwrap();
+/// tree.apply_mut(&mut (
+///     Forward::default(),
+///     ParseType::default(),
+///     EncodingType::default(),
+///     ParseString::default(),
+///     EncodingGetBytes::default(),
+/// )).unwrap();
+///
+/// let mut ps_litter_view = Linter::default();
+/// tree.apply(&mut ps_litter_view).unwrap();
+///
+/// assert_eq!(ps_litter_view.output, "@(102, 111, 111)");
+/// ```
+#[derive(Default)]
+pub struct EncodingGetBytes;
+
+impl<'a> RuleMut<'a> for EncodingGetBytes {
+    type Language = Powershell;
+
+    fn enter(
+        &mut self,
+        _node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        Ok(())
+    }
+
+    fn leave(
+        &mut self,
+        node: &mut NodeMut<'a, Self::Language>,
+        _flow: ControlFlow,
+    ) -> MinusOneResult<()> {
+        let view = node.view();
+        if view.kind() == "member_access"
+            && let (Some(type_lit), Some(op), Some(member_name)) =
+                (view.child(0), view.child(1), view.child(2))
+        {
+            match (
+                type_lit.data(),
+                op.text()?,
+                &member_name.text()?.to_string(),
+                member_name.data(),
+            ) {
+                (Some(Type(typename)), ".", m, _)
+                | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
+                    if is_encoding_tag(typename) && m.clone().normalize() == "getbytes" =>
+                {
+                    let function_typename = format!("{}.getbytes", typename);
+                    trace!(
+                        "EncodingGetBytes (L): Setting node with getbytes type: {:?}",
+                        function_typename
+                    );
+                    node.set(Type(function_typename));
+                }
+                _ => (),
+            }
+        } else if view.kind() == "invokation_expression"
+            && let (Some(type_node), Some(op), Some(member_name), Some(args_list)) =
+                (view.child(0), view.child(1), view.child(2), view.child(3))
+        {
+            match (
+                type_node.data(),
+                op.text()?,
+                &member_name.text()?.to_string(),
+                member_name.data(),
+            ) {
+                (Some(Type(typename)), ".", m, _)
+                | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
+                    if (is_encoding_tag(typename) && m.clone().normalize() == "getbytes")
+                        || (typename.ends_with(".getbytes")
+                            && m.clone().normalize() == "invoke") =>
+                {
+                    let tag = typename
+                        .strip_prefix("text.encoding.")
+                        .and_then(|t| t.strip_suffix(".getbytes").or(Some(t)))
+                        .unwrap_or(typename);
+
+                    if let Some(argument_expression_list) =
+                        args_list.named_child("argument_expression_list")
+                        && let Some(arg_1) = argument_expression_list.child(0)
+                        && let Some(Raw(Str(s))) = arg_1.data()
+                        && let Some(bytes) = encode(tag, s)
+                    {
+                        trace!(
+                            "EncodingGetBytes (L): Setting node with encoded bytes: {:?}",
+                            bytes
+                        );
+                        node.set(Bytes(bytes));
+                    }
+                }
+                _ => (),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ps::Powershell::{Bytes, Raw};
+    use crate::ps::Value::Str;
+    use crate::ps::array::{ComputeArrayExpr, ParseArrayLiteral};
+    use crate::ps::build_powershell_tree;
+    use crate::ps::encoding::{EncodingGetBytes, EncodingGetString, EncodingType};
+    use crate::ps::forward::Forward;
+    use crate::ps::integer::ParseInt;
+    use crate::ps::string::ParseString;
+    use crate::ps::typing::ParseType;
+
+    fn root_data(
+        tree: &crate::tree::Tree<crate::tree::HashMapStorage<crate::ps::Powershell>>,
+    ) -> crate::ps::Powershell {
+        tree.root()
+            .unwrap()
+            .child(0)
+            .unwrap()
+            .child(0)
+            .unwrap()
+            .data()
+            .expect("Inferred type")
+            .clone()
+    }
+
+    #[test]
+    fn test_decode_utf8() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::utf8.getstring(@(102, 111, 111))")
+                .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_decode_unicode() {
+        let mut tree = build_powershell_tree(
+            "[System.Text.Encoding]::Unicode.getstring(@(102, 0, 111, 0, 111, 0))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_decode_bigendianunicode() {
+        let mut tree = build_powershell_tree(
+            "[System.Text.Encoding]::BigEndianUnicode.getstring(@(0, 102, 0, 111, 0, 111))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_decode_utf32() {
+        let mut tree = build_powershell_tree(
+            "[System.Text.Encoding]::utf32.getstring(@(102, 0, 0, 0, 111, 0, 0, 0, 111, 0, 0, 0))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_decode_latin1() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::Latin1.getstring(@(102, 111, 111))")
+                .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_decode_ascii_replaces_high_bytes() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::ascii.getstring(@(102, 200, 111))")
+                .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("f?o".to_string())));
+    }
+
+    #[test]
+    fn test_decode_with_invoke() {
+        let mut tree = build_powershell_tree(
+            "[System.Text.Encoding]::'unicode'.'getstring'.invoke(@(102, 0, 111, 0, 111, 0))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseString::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_getencoding_by_name() {
+        let mut tree = build_powershell_tree(
+            "[System.Text.Encoding]::GetEncoding('utf-8').getstring(@(102, 111, 111))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            ParseString::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_getencoding_by_codepage() {
+        let mut tree = build_powershell_tree(
+            "[System.Text.Encoding]::GetEncoding(28591).getstring(@(102, 111, 111))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_new_constructor() {
+        let mut tree =
+            build_powershell_tree("[System.Text.UTF8Encoding]::new().getstring(@(102, 111, 111))")
+                .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_new_object_constructor() {
+        let mut tree = build_powershell_tree(
+            "(New-Object System.Text.UTF8Encoding).getstring(@(102, 111, 111))",
+        )
+        .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_encode_utf8() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::UTF8.getbytes('foo')").unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseString::default(),
+            EncodingGetBytes::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Bytes(vec![102, 111, 111]));
+    }
+
+    #[test]
+    fn test_encode_unicode() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::Unicode.getbytes('foo')").unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseString::default(),
+            EncodingGetBytes::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Bytes(vec![102, 0, 111, 0, 111, 0]));
+    }
+
+    #[test]
+    fn test_encode_ascii_replaces_out_of_range() {
+        let source = format!("[System.Text.Encoding]::ASCII.getbytes('{}')", '\u{1234}');
+        let mut tree = build_powershell_tree(&source).unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseString::default(),
+            EncodingGetBytes::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Bytes(vec![63]));
+    }
+
+    #[test]
+    fn test_decode_default_pure_ascii() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::Default.getstring(@(102, 111, 111))")
+                .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(root_data(&tree), Raw(Str("foo".to_string())));
+    }
+
+    #[test]
+    fn test_decode_default_non_ascii_is_not_resolved() {
+        let mut tree =
+            build_powershell_tree("[System.Text.Encoding]::Default.getstring(@(102, 200, 111))")
+                .unwrap();
+        tree.apply_mut(&mut (
+            Forward::default(),
+            ParseType::default(),
+            EncodingType::default(),
+            ParseInt::default(),
+            ParseArrayLiteral::default(),
+            ComputeArrayExpr::default(),
+            EncodingGetString::default(),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            tree.root()
+                .unwrap()
+                .child(0)
+                .unwrap()
+                .child(0)
+                .unwrap()
+                .data(),
+            None
+        );
+    }
+}

--- a/core/src/ps/linter.rs
+++ b/core/src/ps/linter.rs
@@ -1,5 +1,5 @@
 use crate::error::MinusOneResult;
-use crate::ps::Powershell::Raw;
+use crate::ps::Powershell::{Bytes, Raw};
 use crate::ps::Value::{Bool, Num, Str};
 use crate::ps::tool::StringTool;
 use crate::ps::utils::string::escape_string;
@@ -315,6 +315,17 @@ impl<'a> Rule<'a> for Linter {
                 }
                 Raw(Bool(false)) => {
                     self.write("$false".to_string().as_str());
+                    return Ok(false);
+                }
+                Bytes(bytes) => {
+                    let joined = bytes
+                        .iter()
+                        .map(|b| b.to_string())
+                        .collect::<Vec<String>>()
+                        .join(", ");
+                    self.write("@(");
+                    self.write(&joined);
+                    self.write(")");
                     return Ok(false);
                 }
                 _ => (),

--- a/core/src/ps/method.rs
+++ b/core/src/ps/method.rs
@@ -71,6 +71,16 @@ impl<'a> RuleMut<'a> for Length {
                     );
                     node.set(Raw(Num(value.len() as i64)))
                 }
+                (Some(Powershell::Bytes(value)), ".", m, _)
+                | (Some(Powershell::Bytes(value)), ".", _, Some(Raw(Str(m))))
+                    if m.clone().normalize() == "length" =>
+                {
+                    trace!(
+                        "Length (L): Setting node with bytes length: {}",
+                        value.len()
+                    );
+                    node.set(Raw(Num(value.len() as i64)))
+                }
                 (Some(Raw(Str(s))), ".", m, None)
                 | (Some(Raw(Str(s))), ".", _, Some(Raw(Str(m))))
                     if m.clone().normalize() == "length" =>
@@ -87,7 +97,10 @@ impl<'a> RuleMut<'a> for Length {
 
 /// This rule will infer the [System.Convert]::FromBase64String function
 ///
-/// [System.Text.Encoding]::utf8.getstring([System.Convert]::FromBase64String('Zm9v')) => 'foo'
+/// [System.Convert]::FromBase64String('Zm9v') => @(102, 111, 111)
+///
+/// Combined with [`crate::ps::encoding::EncodingGetString`], this lets a full
+/// `[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('Zm9v'))` chain fold to `'foo'`.
 ///
 /// # Example
 /// ```
@@ -100,7 +113,8 @@ impl<'a> RuleMut<'a> for Length {
 /// use minusone::ps::linter::Linter;
 /// use minusone::ps::string::ParseString;
 /// use minusone::ps::typing::ParseType;
-/// use minusone::ps::method::{DecodeBase64, FromUTF};
+/// use minusone::ps::method::DecodeBase64;
+/// use minusone::ps::encoding::{EncodingType, EncodingGetString};
 ///
 /// let mut tree = build_powershell_tree("[System.Text.Encoding]::utf8.getstring([System.Convert]::FromBase64String('Zm9v'))").unwrap();
 /// tree.apply_mut(&mut (
@@ -108,7 +122,8 @@ impl<'a> RuleMut<'a> for Length {
 ///     Forward::default(),
 ///     ParseType::default(),
 ///     DecodeBase64::default(),
-///     FromUTF::default()
+///     EncodingType::default(),
+///     EncodingGetString::default()
 /// )).unwrap();
 ///
 /// let mut ps_litter_view = Linter::default();
@@ -188,13 +203,11 @@ impl<'a> RuleMut<'a> for DecodeBase64 {
                     {
                         match general_purpose::STANDARD.decode(s) {
                             Ok(bytes) => {
-                                let decoded_array: Vec<_> =
-                                    bytes.iter().map(|b| Num(*b as i64)).collect();
                                 trace!(
-                                    "DecodeBase64 (L): Setting node with decoded base64 array: {:?}",
-                                    decoded_array
+                                    "DecodeBase64 (L): Setting node with decoded bytes: {:?}",
+                                    bytes
                                 );
-                                node.set(Array(decoded_array));
+                                node.set(Powershell::Bytes(bytes));
                             }
                             Err(e) => {
                                 warn!(
@@ -213,197 +226,16 @@ impl<'a> RuleMut<'a> for DecodeBase64 {
     }
 }
 
-/// This rule will infer the [System.Text.Encoding]::utf8.getstring function
-///
-/// [System.Text.Encoding]::utf8.getstring([System.Convert]::FromBase64String('Zm9v')) => 'foo'
-///
-/// # Example
-/// ```
-/// extern crate tree_sitter;
-/// extern crate tree_sitter_powershell;
-///
-/// use minusone::tree::{HashMapStorage, Tree};
-/// use minusone::ps::build_powershell_tree;
-/// use minusone::ps::forward::Forward;
-/// use minusone::ps::linter::Linter;
-/// use minusone::ps::string::ParseString;
-/// use minusone::ps::typing::ParseType;
-/// use minusone::ps::method::{DecodeBase64, FromUTF};
-///
-/// let mut tree = build_powershell_tree("[System.Text.Encoding]::utf8.getstring([System.Convert]::FromBase64String('Zm9v'))").unwrap();
-/// tree.apply_mut(&mut (
-///     ParseString::default(),
-///     Forward::default(),
-///     ParseType::default(),
-///     DecodeBase64::default(),
-///     FromUTF::default()
-/// )).unwrap();
-///
-/// let mut ps_litter_view = Linter::default();
-/// tree.apply(&mut ps_litter_view).unwrap();
-///
-/// assert_eq!(ps_litter_view.output, "\"foo\"");
-/// ```
-#[derive(Default)]
-pub struct FromUTF;
-
-impl<'a> RuleMut<'a> for FromUTF {
-    type Language = Powershell;
-
-    fn enter(
-        &mut self,
-        _node: &mut NodeMut<'a, Self::Language>,
-        _flow: ControlFlow,
-    ) -> MinusOneResult<()> {
-        Ok(())
-    }
-
-    fn leave(
-        &mut self,
-        node: &mut NodeMut<'a, Self::Language>,
-        _flow: ControlFlow,
-    ) -> MinusOneResult<()> {
-        let view = node.view();
-        if view.kind() == "member_access" {
-            if let (Some(type_lit), Some(op), Some(member_name)) =
-                (view.child(0), view.child(1), view.child(2))
-            {
-                match (
-                    type_lit.data(),
-                    op.text()?,
-                    &member_name.text()?.to_string(),
-                    member_name.data(),
-                ) {
-                    (Some(Type(typename)), "::", m, _)
-                    | (Some(Type(typename)), "::", _, Some(Raw(Str(m))))
-                        if ["utf8", "utf16", "unicode", "ascii"]
-                            .contains(&m.clone().normalize().as_str())
-                            && (typename == "system.text.encoding"
-                                || typename == "text.encoding") =>
-                    {
-                        // infer type of member access
-                        let mut function_typename = String::from("text.encoding.");
-                        function_typename += &m.clone().normalize();
-                        trace!(
-                            "FromUTF (L): Setting node with encoding type: {:?}",
-                            function_typename
-                        );
-                        node.set(Type(function_typename));
-                    }
-
-                    (Some(Type(typename)), ".", m, _)
-                    | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
-                        if [
-                            "text.encoding.utf8",
-                            "text.encoding.utf16",
-                            "text.encoding.unicode",
-                            "text.encoding.ascii",
-                        ]
-                        .contains(&typename.as_str())
-                            && m.clone().normalize() == "getstring" =>
-                    {
-                        let mut function_typename = typename.clone();
-                        function_typename += ".getstring";
-                        trace!(
-                            "FromUTF (L): Setting node with getstring type: {:?}",
-                            function_typename
-                        );
-                        node.set(Type(function_typename));
-                    }
-                    _ => (),
-                }
-            }
-        } else if view.kind() == "invokation_expression"
-            && let (Some(type_node), Some(op), Some(member_name), Some(args_list)) =
-                (view.child(0), view.child(1), view.child(2), view.child(3))
-        {
-            match (
-                type_node.data(),
-                op.text()?,
-                &member_name.text()?.to_string(),
-                member_name.data(),
-            ) {
-                (Some(Type(typename)), ".", m, _)
-                | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
-                    if ((typename == "text.encoding.utf8"
-                        || typename == "text.encoding.ascii")
-                        && m.clone().normalize() == "getstring")
-                        || ((typename == "text.encoding.utf8.getstring"
-                            || typename == "text.encoding.ascii.getstring")
-                            && m.clone().normalize() == "invoke") =>
-                {
-                    if let Some(argument_expression_list) =
-                        args_list.named_child("argument_expression_list")
-                        && let Some(arg_1) = argument_expression_list.child(0)
-                        && let Some(Array(a)) = arg_1.data()
-                    {
-                        let mut int_vec = Vec::new();
-                        for value in a.iter() {
-                            if let Num(n) = value {
-                                int_vec.push(*n as u8);
-                            }
-                        }
-                        if let Ok(s) = String::from_utf8(int_vec) {
-                            trace!(
-                                "FromUTF (L): Setting node with UTF-8 decoded string: {:?}",
-                                s
-                            );
-                            node.set(Raw(Str(s)));
-                        }
-                    }
-                }
-                (Some(Type(typename)), ".", m, _)
-                | (Some(Type(typename)), ".", _, Some(Raw(Str(m))))
-                    if ((typename == "text.encoding.utf16"
-                        || typename == "text.encoding.unicode")
-                        && m.clone().normalize() == "getstring")
-                        || ((typename == "text.encoding.utf16.getstring"
-                            || typename == "text.encoding.unicode.getstring")
-                            && m.clone().normalize() == "invoke") =>
-                {
-                    if let Some(argument_expression_list) =
-                        args_list.named_child("argument_expression_list")
-                        && let Some(arg_1) = argument_expression_list.child(0)
-                        && let Some(Array(a)) = arg_1.data()
-                    {
-                        let mut int_vec = Vec::new();
-                        for value in a.iter() {
-                            if let Num(n) = value {
-                                int_vec.push(*n as u8);
-                            }
-                        }
-
-                        let int_vec: Vec<u16> = int_vec
-                            .chunks_exact(2)
-                            .map(|a| u16::from_ne_bytes([a[0], a[1]]))
-                            .collect();
-                        let int_vec = int_vec.as_slice();
-
-                        if let Ok(s) = String::from_utf16(int_vec) {
-                            trace!(
-                                "FromUTF (L): Setting node with UTF-16 decoded string: {:?}",
-                                s
-                            );
-                            node.set(Raw(Str(s)));
-                        }
-                    }
-                }
-                _ => (),
-            }
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use crate::ps::Powershell::{Array, Raw};
-    use crate::ps::Value::{Num, Str};
+    use crate::ps::Powershell;
+    use crate::ps::Powershell::Raw;
+    use crate::ps::Value::Num;
     use crate::ps::array::{ComputeArrayExpr, ParseArrayLiteral};
     use crate::ps::build_powershell_tree;
     use crate::ps::forward::Forward;
     use crate::ps::integer::ParseInt;
-    use crate::ps::method::{DecodeBase64, FromUTF, Length};
+    use crate::ps::method::{DecodeBase64, Length};
     use crate::ps::string::ParseString;
     use crate::ps::typing::ParseType;
 
@@ -480,7 +312,7 @@ mod test {
                 .unwrap()
                 .data()
                 .expect("Inferred type"),
-            Array(vec![Num(102), Num(111), Num(111)])
+            Powershell::Bytes(vec![102, 111, 111])
         );
     }
 
@@ -530,96 +362,6 @@ mod test {
                 .unwrap()
                 .data(),
             None
-        );
-    }
-
-    #[test]
-    fn test_decode_utf8() {
-        let mut tree =
-            build_powershell_tree("[System.Text.Encoding]::utf8.getstring(@(102, 111, 111))")
-                .unwrap();
-        tree.apply_mut(&mut (
-            Forward::default(),
-            FromUTF::default(),
-            ParseType::default(),
-            ParseInt::default(),
-            ParseArrayLiteral::default(),
-            ComputeArrayExpr::default(),
-        ))
-        .unwrap();
-
-        assert_eq!(
-            *tree
-                .root()
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .data()
-                .expect("Inferred type"),
-            Raw(Str("foo".to_string()))
-        );
-    }
-
-    #[test]
-    fn test_decode_utf16() {
-        let mut tree = build_powershell_tree(
-            "[System.Text.Encoding]::utf16.getstring(@(102, 0, 111, 0, 111, 0))",
-        )
-        .unwrap();
-        tree.apply_mut(&mut (
-            Forward::default(),
-            FromUTF::default(),
-            ParseType::default(),
-            ParseInt::default(),
-            ParseArrayLiteral::default(),
-            ComputeArrayExpr::default(),
-        ))
-        .unwrap();
-
-        assert_eq!(
-            *tree
-                .root()
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .data()
-                .expect("Inferred type"),
-            Raw(Str("foo".to_string()))
-        );
-    }
-
-    #[test]
-    fn test_decode_utf16_with_invoke() {
-        let mut tree = build_powershell_tree(
-            "[System.Text.Encoding]::'utf16'.'getstring'.invoke(@(102, 0, 111, 0, 111, 0))",
-        )
-        .unwrap();
-        tree.apply_mut(&mut (
-            Forward::default(),
-            FromUTF::default(),
-            ParseType::default(),
-            ParseInt::default(),
-            ParseString::default(),
-            ParseArrayLiteral::default(),
-            ComputeArrayExpr::default(),
-        ))
-        .unwrap();
-
-        assert_eq!(
-            *tree
-                .root()
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .child(0)
-                .unwrap()
-                .data()
-                .expect("Inferred type"),
-            Raw(Str("foo".to_string()))
         );
     }
 }

--- a/core/src/ps/mod.rs
+++ b/core/src/ps/mod.rs
@@ -2,6 +2,7 @@ use self::access::*;
 use self::array::*;
 use self::bool::*;
 use self::cast::*;
+use self::encoding::*;
 use self::foreach::*;
 use self::forward::*;
 use self::hash::*;
@@ -27,6 +28,7 @@ pub mod backend;
 pub mod bool;
 pub mod cast;
 pub mod comparison;
+pub mod encoding;
 pub mod foreach;
 pub mod forward;
 pub mod hash;
@@ -114,6 +116,7 @@ pub enum Powershell {
     HashMap(BTreeMap<Value, Value>),
     HashEntry(Value, Value),
     Type(String), // Will infer type
+    Bytes(Vec<u8>),
     Unknown,
 }
 
@@ -176,7 +179,9 @@ impl_powershell_ruleset!(
     Not,          // It will infer the ! operator
     ParseType,    // Parse type
     DecodeBase64, // Decode calls to FromBase64
-    FromUTF,      // Decode calls to FromUTF{8,16}.GetText
+    EncodingType, // Resolve [System.Text.Encoding] statics, constructors and GetEncoding(...)
+    EncodingGetString, // Decode calls to Encoding.GetString(byte[])
+    EncodingGetBytes, // Encode calls to Encoding.GetBytes(string)
     NewStringMethod, // Infer [System.String]::new(@(char codes)) constructor
     Length,       // Decode attribute length of string and array
     BoolAlgebra,  // Add support to boolean algebra (or and)

--- a/core/src/ps/utils/bytes.rs
+++ b/core/src/ps/utils/bytes.rs
@@ -1,0 +1,21 @@
+use crate::ps::Powershell;
+use crate::ps::Powershell::{Array, Bytes};
+use crate::ps::Value::Num;
+
+pub fn bytes_from_array(values: &[crate::ps::Value]) -> Option<Vec<u8>> {
+    values
+        .iter()
+        .map(|v| match v {
+            Num(n) if (0..=255).contains(n) => Some(*n as u8),
+            _ => None,
+        })
+        .collect()
+}
+
+pub fn bytes_from_data(data: &Powershell) -> Option<Vec<u8>> {
+    match data {
+        Array(a) => bytes_from_array(a),
+        Bytes(b) => Some(b.clone()),
+        _ => None,
+    }
+}

--- a/core/src/ps/utils/mod.rs
+++ b/core/src/ps/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod bytes;
 pub mod conversion;
 pub mod string;

--- a/core/src/ps/utils/string.rs
+++ b/core/src/ps/utils/string.rs
@@ -46,3 +46,100 @@ pub fn escape_string(src: &str) -> String {
     }
     result
 }
+
+// latin + ascii https://en.wikipedia.org/wiki/Code_page#Various_other_Microsoft_code_pages
+// UTF-x + unicode https://en.wikipedia.org/wiki/Code_page#Microsoft_Unicode_code_pages
+pub fn encoding_codepage_tag(codepage: i64) -> Option<&'static str> {
+    match codepage {
+        20127 => Some("ascii"),
+        65001 => Some("utf8"),
+        1200 => Some("unicode"),
+        1201 => Some("bigendianunicode"),
+        12000 => Some("utf32"),
+        28591 => Some("latin1"),
+        _ => None,
+    }
+}
+
+pub fn encoding_name_tag(name: &str) -> Option<&'static str> {
+    match name {
+        "ascii" | "us-ascii" => Some("ascii"),
+        "utf-8" | "utf8" => Some("utf8"),
+        "utf-16" | "utf-16le" | "unicode" => Some("unicode"),
+        "utf-16be" | "bigendianunicode" => Some("bigendianunicode"),
+        "utf-32" | "utf-32le" => Some("utf32"),
+        "iso-8859-1" | "latin1" => Some("latin1"),
+        _ => None,
+    }
+}
+
+pub fn decode(tag: &str, bytes: &[u8]) -> Option<String> {
+    match tag {
+        "ascii" => Some(
+            bytes
+                .iter()
+                .map(|&b| if b < 128 { b as char } else { '?' })
+                .collect(),
+        ),
+        "default" if bytes.iter().all(|&b| b < 128) => {
+            Some(bytes.iter().map(|&b| b as char).collect())
+        }
+        "latin1" => Some(bytes.iter().map(|&b| b as char).collect()),
+        "utf8" => String::from_utf8(bytes.to_vec()).ok(),
+        "unicode" => {
+            if bytes.len() % 2 != 0 {
+                return None;
+            }
+            let units: Vec<u16> = bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect();
+            String::from_utf16(&units).ok()
+        }
+        "bigendianunicode" => {
+            if bytes.len() % 2 != 0 {
+                return None;
+            }
+            let units: Vec<u16> = bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_be_bytes([c[0], c[1]]))
+                .collect();
+            String::from_utf16(&units).ok()
+        }
+        "utf32" => {
+            if bytes.len() % 4 != 0 {
+                return None;
+            }
+            let mut result = String::with_capacity(bytes.len() / 4);
+            for chunk in bytes.chunks_exact(4) {
+                let codepoint = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                result.push(char::from_u32(codepoint)?);
+            }
+            Some(result)
+        }
+        _ => None,
+    }
+}
+
+pub fn encode(tag: &str, s: &str) -> Option<Vec<u8>> {
+    match tag {
+        "ascii" => Some(
+            s.chars()
+                .map(|c| if (c as u32) < 128 { c as u8 } else { b'?' })
+                .collect(),
+        ),
+        "default" if s.chars().all(|c| (c as u32) < 128) => {
+            Some(s.chars().map(|c| c as u8).collect())
+        }
+        "latin1" => Some(
+            s.chars()
+                .map(|c| if (c as u32) <= 0xFF { c as u8 } else { b'?' })
+                .collect(),
+        ),
+        "utf8" => Some(s.as_bytes().to_vec()),
+        "unicode" => Some(s.encode_utf16().flat_map(|u| u.to_le_bytes()).collect()),
+        "bigendianunicode" => Some(s.encode_utf16().flat_map(|u| u.to_be_bytes()).collect()),
+        "utf32" => Some(s.chars().flat_map(|c| (c as u32).to_le_bytes()).collect()),
+        _ => None,
+    }
+}

--- a/core/src/rule.rs
+++ b/core/src/rule.rs
@@ -286,4 +286,6 @@ mod impl_data {
     impl_data!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL);
     impl_data!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM);
     impl_data!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN);
+    impl_data!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO);
+    impl_data!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP);
 }


### PR DESCRIPTION
Minusone can fully handle conversion of strings to bytes and vice versa. All the possible encodings (`ascii`, `defaut`, `latin1`, `utf8`, `unicode`, `bigendianunicode` and `utf32`). I also added the `Byte` Powershell type to have a better ways to manage bytes, espectaliy after a b64/urldecode conversion.

Closes #210 