### PR TITLE
Fixes for #238, #237 and #236

### DIFF
--- a/core/src/js/functions/fncall.rs
+++ b/core/src/js/functions/fncall.rs
@@ -248,6 +248,28 @@ impl FnCall {
         Some(args)
     }
 
+    fn catch_or_finally_has_return(try_node: &Node<JavaScript>) -> bool {
+        for child in try_node.iter() {
+            if matches!(child.kind(), "catch_clause" | "finally_clause") {
+                let mut count = 0;
+                Self::count_returns_in_subtree(&child, &mut count);
+                if count > 0 {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    // `try { ...; return X; } catch {}` (no finally, catch doesn't itself return)
+    fn try_statement_return_value(try_node: &Node<JavaScript>) -> Option<JavaScript> {
+        if Self::catch_or_finally_has_return(try_node) {
+            return None;
+        }
+        let body = try_node.named_child("body")?;
+        Self::extract_top_level_return_value(&body)
+    }
+
     fn extract_top_level_return_value(root: &Node<JavaScript>) -> Option<JavaScript> {
         if Self::has_nested_return_in_control_flow(root) {
             return None;
@@ -263,6 +285,11 @@ impl FnCall {
                 }
                 return None;
             }
+            if child.kind() == "try_statement"
+                && let Some(value) = Self::try_statement_return_value(&child)
+            {
+                return Some(value);
+            }
         }
         None
     }
@@ -271,10 +298,20 @@ impl FnCall {
         for child in node.iter() {
             match child.kind() {
                 "if_statement" | "while_statement" | "do_statement" | "for_statement"
-                | "for_in_statement" | "switch_statement" | "try_statement" => {
+                | "for_in_statement" | "switch_statement" => {
                     let mut count = 0;
                     Self::count_returns_in_subtree(&child, &mut count);
                     if count > 0 {
+                        return true;
+                    }
+                }
+                "try_statement" => {
+                    if Self::catch_or_finally_has_return(&child) {
+                        return true;
+                    }
+                    if let Some(body) = child.named_child("body")
+                        && Self::has_nested_return_in_control_flow(&body)
+                    {
                         return true;
                     }
                 }
@@ -522,6 +559,23 @@ impl FnCall {
         None
     }
 
+    fn declaration_keyword(node: &Node<JavaScript>) -> Option<&'static str> {
+        match node.kind() {
+            "variable_declaration" => Some("var"),
+            "lexical_declaration" => {
+                for child in node.iter() {
+                    match child.kind() {
+                        "let" => return Some("let"),
+                        "const" => return Some("const"),
+                        _ => {}
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
     fn collect_fn_decls(program: &Node<JavaScript>) -> Vec<(String, String)> {
         let mut decls = Vec::new();
         for child in program.iter() {
@@ -534,6 +588,29 @@ impl FnCall {
                 && let Ok(src) = child.text()
             {
                 decls.push((name.to_string(), src.to_string()));
+                continue;
+            }
+
+            if let Some(keyword) = Self::declaration_keyword(&child) {
+                for declarator in child.iter().filter(|c| c.kind() == "variable_declarator") {
+                    if let Some(name_node) = declarator.named_child("name")
+                        && name_node.kind() == "identifier"
+                        && let Ok(name) = name_node.text()
+                        && let Some(value_node) = declarator
+                            .named_child("value")
+                            .or_else(|| declarator.child(2))
+                        && matches!(
+                            value_node.kind(),
+                            "function"
+                                | "function_expression"
+                                | "arrow_function"
+                                | "generator_function"
+                        )
+                        && let Ok(value_src) = value_node.text()
+                    {
+                        decls.push((name.to_string(), format!("{keyword} {name} = {value_src};")));
+                    }
+                }
             }
         }
         decls

--- a/core/src/js/post_process.rs
+++ b/core/src/js/post_process.rs
@@ -717,6 +717,14 @@ impl RemoveUnused {
             | "assignment_expression"
             | "augmented_assignment_expression"
             | "update_expression" => true,
+            // defining a function has no side effect itself, only calling it does
+            "function"
+            | "function_expression"
+            | "function_declaration"
+            | "arrow_function"
+            | "generator_function"
+            | "generator_function_declaration"
+            | "method_definition" => false,
             _ => node.iter().any(|child| Self::has_side_effects(&child)),
         }
     }

--- a/core/src/js/tests/fncall_tests.rs
+++ b/core/src/js/tests/fncall_tests.rs
@@ -245,4 +245,66 @@ mod test_fncall {
             "function test(a, b) { return b; } console.log(undefined);"
         );
     }
+
+    #[test]
+    fn test_fncall_return_inside_try_with_empty_catch() {
+        assert_eq!(
+            deobfuscate(
+                "function test(x) { try { return x + 1; } catch {} } console.log(test(1));"
+            ),
+            "function test(x) { try { return x + 1; } catch {} } console.log(2);"
+        );
+    }
+
+    #[test]
+    fn test_fncall_return_inside_try_bails_when_catch_also_returns() {
+        let out = deobfuscate(
+            "function test(x) { try { return x + 1; } catch { return -1; } } console.log(test(1));",
+        );
+        assert!(out.contains("console.log(test(1));"));
+    }
+
+    #[test]
+    fn test_fncall_resolves_call_to_const_function_expression() {
+        assert_eq!(
+            deobfuscate("const test = function (x) { return x + 1; }; console.log(test(1));"),
+            "const test = function (x) { return x + 1; }; console.log(2);"
+        );
+    }
+
+    #[test]
+    fn test_fncall_resolves_nested_call_between_const_functions() {
+        assert_eq!(
+            deobfuscate(
+                "const inner = function (x) { return x + 1; }, outer = function (x) { return inner(x) + 1; }; console.log(outer(1));"
+            ),
+            "const inner = function (x) { return x + 1; }, outer = function (x) { return inner(x) + 1; }; console.log(3);"
+        );
+    }
+
+    #[test]
+    fn test_fncall_param_shadows_outer_var_of_same_name() {
+        assert_eq!(
+            deobfuscate("var a = 5; function f(a) { return a + 1; } console.log(f(10));"),
+            "var a = 5; function f(a) { return a + 1; } console.log(11);"
+        );
+    }
+
+    #[test]
+    fn test_fncall_nested_calls_shadow_same_param_name() {
+        assert_eq!(
+            deobfuscate(
+                "const inner = function (x, r) { return x + r; }, outer = function (x, r) { return inner(x + 1, r); }; console.log(outer(1, 10));"
+            ),
+            "const inner = function (x, r) { return x + r; }, outer = function (x, r) { return inner(x + 1, r); }; console.log(12);"
+        );
+    }
+
+    #[test]
+    fn test_fncall_reassignment_in_try_keeps_call_args_known() {
+        let out = deobfuscate(
+            "function inner(x, r) { return x + r; } function getStr(x, r) { return inner(x, r); } const yo = 'yo'; function entry(x) { try { let n = ''; n = getStr('hi', yo); return n; } catch {} } console.log(entry('a'));",
+        );
+        assert!(out.contains("getStr('hi', 'yo')"), "got: {out}");
+    }
 }

--- a/core/src/js/tests/post_process_tests.rs
+++ b/core/src/js/tests/post_process_tests.rs
@@ -99,6 +99,14 @@ mod test_js_post_process {
     }
 
     #[test]
+    fn test_remove_unused_const_function_with_calls_in_body() {
+        assert_eq!(
+            clean("const helper = function (x) { return String(x).trim(); }; console.log('ok');"),
+            "console.log('ok');"
+        );
+    }
+
+    #[test]
     fn test_keep_mixed() {
         assert_eq!(
             clean("var a = 1; var b = 2; console.log(a);"),

--- a/core/src/js/utils.rs
+++ b/core/src/js/utils.rs
@@ -99,6 +99,13 @@ pub fn is_write_target(node: &Node<JavaScript>) -> bool {
 
     while let Some(parent) = current {
         match parent.kind() {
+            "formal_parameters" | "catch_clause" => return true,
+            "assignment_pattern" => {
+                if let Some(left) = parent.child(0) {
+                    return child_start >= left.start_abs() && child_end <= left.end_abs();
+                }
+                return false;
+            }
             "variable_declarator" => {
                 if let Some(name_child) = parent.child(0) {
                     return child_start >= name_child.start_abs()

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -50,19 +50,46 @@ pub struct Var {
 }
 
 impl Var {
+    fn forget_parameter_names(
+        &mut self,
+        node: &Node<JavaScript>,
+        ongoing_transaction: bool,
+    ) -> MinusOneResult<()> {
+        for child in node.iter() {
+            if child.kind() == "identifier" && is_write_target(&child) {
+                let name = child.text()?.to_string();
+                self.scope_manager
+                    .current_mut()
+                    .forget(&name, ongoing_transaction);
+            } else {
+                self.forget_parameter_names(&child, ongoing_transaction)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn is_assignment_write_target<T>(node: &Node<T>) -> bool {
+        let Some(parent) = node.get_parent_of_types(vec![
+            "assignment_expression",
+            "augmented_assignment_expression",
+            "update_expression",
+        ]) else {
+            return false;
+        };
+        if parent.kind() == "update_expression" {
+            return true;
+        }
+        let Some(left) = parent.child(0) else {
+            return false;
+        };
+        node.start_abs() >= left.start_abs() && node.end_abs() <= left.end_abs()
+    }
+
     fn forget_assigned_var<T>(&mut self, node: &Node<T>) -> MinusOneResult<()> {
         for child in node.iter() {
             match child.kind() {
                 "identifier" => {
-                    // if identifier is on the left side of an assignment
-                    if child
-                        .get_parent_of_types(vec![
-                            "assignment_expression",
-                            "augmented_assignment_expression",
-                            "update_expression",
-                        ])
-                        .is_some()
-                    {
+                    if Self::is_assignment_write_target(&child) {
                         let var_name = child.text()?.to_string();
                         self.scope_manager
                             .current_mut()
@@ -166,6 +193,16 @@ impl<'a> RuleMut<'a> for Var {
             | "generator_function_declaration"
             | "generator_function" => {
                 self.scope_manager.enter();
+                let ongoing = view.is_ongoing_transaction();
+                if let Some(params) = view.named_child("parameters") {
+                    self.forget_parameter_names(&params, ongoing)?;
+                } else if view.kind() == "arrow_function"
+                    && let Some(param) = view.named_child("parameter")
+                    && param.kind() == "identifier"
+                {
+                    let name = param.text()?.to_string();
+                    self.scope_manager.current_mut().forget(&name, ongoing);
+                }
                 if let Some(body) = view.named_child("body") {
                     self.forget_assigned_var(&body)?;
                 }
@@ -562,7 +599,7 @@ impl<'a> RuleMut<'a> for Var {
                         .forget(&var_name, node.is_ongoing_transaction());
                 }
             }
-            // `eval(...)` can mutate any local
+            // `eval(...)` can mutate any local variable
             "call_expression" => {
                 if let Some(func) = view.named_child("function").or_else(|| view.child(0))
                     && func.kind() == "identifier"


### PR DESCRIPTION
Fixes 4 major bugs

### `try { return X } catch {}` blocked call folding entirely

Any function with a `return` inside a `try` block was treated as fully unresolvable, so calls to it could never be folded. Fixed to unwrap a "safe" try/catch (empty/non-returning `catch` or `finally`) and extract the return as if it were top-level.

### `const x = function(){}` invisible to nested-call resolution

Only `function` declarations were hoisted into the pool of declarations a sub-program simulation can pull in so `const`/`let`/`var` assignments of function expressions were not. So when function A (itself `const`-declared) called function B (also `const`-declared) internally, B's declaration wasn't available when A's body was extracted into its own sub-program, and the nested call never resolved (I don't know if it's clear). Fixed by also collecting function-valued declarators.

### Function parameters didn't shadow same-named outer variables

```js
var a = 5;
function f(a) { return a + 1; }
console.log(f(10)); // minusone said 6, should be 11
```
`is_write_target` didn't recognize `formal_parameters`/`catch_clause`, so it kept walking past the function boundary looking for a write-target context, usually landing on "not a write target". So the parameter looked like a plain read and inherited the outer scope's stale value instead of shadowing it. Also, entering a function scope never explicitly cleared a parameter's inherited value. Fixed both: `is_write_target` now short-circuits on parameter/catch bindings, and `Var` forgets each parameter's name on function-scope entry.

### Dead functions with calls in their own body weren't fully removed

`RemoveUnused` decides whether an unused declaration can be deleted outright or must be reduced to just its side-effecting initializer, via `has_side_effects`. So an unused `const helper = function(x) { return String(x).trim(); };` looked like it "had side effects" (because calls appear inside its body). Fixed by stopping the recursion at function boundaries.

Closes #238 Closes #237 Closes #236