### PR TITLE
Iterable objects in `for ... in ...`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ colored = "3"
 ecb = "0.2.0"
 flate2 = { version = "1.1.5", default-features = false, features = ["rust_backend"] }
 half = "2.7.1"
+indexmap = "2"
 log = { workspace = true }
 num = "0.4.3"
 num-bigint = "0.4.6"

--- a/core/src/js/globals.rs
+++ b/core/src/js/globals.rs
@@ -2,11 +2,12 @@ use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::*;
 use crate::scope::Scope;
+use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::f64::consts::*;
 
 fn number_obj() -> JavaScript {
-    let mut number = HashMap::new();
+    let mut number = IndexMap::new();
     number.insert("name".to_string(), Raw(Str("Number".to_string())));
     number.insert("MAX_VALUE".to_string(), Raw(Num(f64::MAX)));
     number.insert("MIN_VALUE".to_string(), Raw(Num(f64::MIN_POSITIVE)));
@@ -26,7 +27,7 @@ fn number_obj() -> JavaScript {
 }
 
 fn math_obj() -> JavaScript {
-    let mut number = HashMap::new();
+    let mut number = IndexMap::new();
     number.insert("E".to_string(), Raw(Num(E)));
     number.insert("LN10".to_string(), Raw(Num(LN_10)));
     number.insert("LN2".to_string(), Raw(Num(LN_2)));
@@ -42,7 +43,7 @@ fn math_obj() -> JavaScript {
 }
 
 fn string_obj() -> JavaScript {
-    let mut string = HashMap::new();
+    let mut string = IndexMap::new();
     string.insert("name".to_string(), Raw(Str("String".to_string())));
     Object {
         map: string,
@@ -51,7 +52,7 @@ fn string_obj() -> JavaScript {
 }
 
 fn regexp_obj() -> JavaScript {
-    let mut string = HashMap::new();
+    let mut string = IndexMap::new();
     string.insert("name".to_string(), Raw(Str("RegExp".to_string())));
     Object {
         map: string,

--- a/core/src/js/iterator.rs
+++ b/core/src/js/iterator.rs
@@ -5,8 +5,8 @@ use crate::js::utils::{get_positional_arguments, method_name};
 use crate::js::{IteratorKind, JavaScript};
 use crate::rule::RuleMut;
 use crate::tree::{ControlFlow, NodeMut};
+use indexmap::IndexMap;
 use log::trace;
-use std::collections::HashMap;
 
 type IteratorBuiltinHandler = fn(&mut JavaScript, &[JavaScript]) -> Option<JavaScript>;
 
@@ -105,7 +105,7 @@ fn iterator_builtin_next(iter: &mut JavaScript, _args: &[JavaScript]) -> Option<
 
             *index += 1;
 
-            let mut map = HashMap::new();
+            let mut map = IndexMap::new();
             map.insert("value".to_string(), value);
             map.insert("done".to_string(), Raw(Bool(false)));
 
@@ -114,7 +114,7 @@ fn iterator_builtin_next(iter: &mut JavaScript, _args: &[JavaScript]) -> Option<
                 to_string_override: None,
             })
         } else {
-            let mut map = HashMap::new();
+            let mut map = IndexMap::new();
             map.insert("value".to_string(), Undefined);
             map.insert("done".to_string(), Raw(Bool(true)));
 

--- a/core/src/js/mod.rs
+++ b/core/src/js/mod.rs
@@ -60,7 +60,7 @@ use self::var::*;
 use crate::error::{Error, MinusOneResult};
 use crate::rule::{RuleMut, RuleSet, RuleSetBuilderType};
 use crate::tree::{HashMapStorage, Storage, Tree};
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use tree_sitter_javascript::LANGUAGE as javascript_language;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -98,7 +98,7 @@ pub enum JavaScript {
     Bytes(Vec<u8>),
     Buffer(Vec<u8>),
     Object {
-        map: HashMap<String, JavaScript>,
+        map: IndexMap<String, JavaScript>,
         to_string_override: Option<String>,
     },
     Iterator {

--- a/core/src/js/objects/object.rs
+++ b/core/src/js/objects/object.rs
@@ -9,8 +9,8 @@ use crate::js::utils::{get_positional_arguments, is_write_target};
 use crate::rule::RuleMut;
 use crate::scope::ScopeManager;
 use crate::tree::{ControlFlow, Node, NodeMut};
+use indexmap::IndexMap;
 use log::{trace, warn};
-use std::collections::HashMap;
 
 /// Parses JavaScript objects into `Object(_)`.
 #[derive(Default)]
@@ -58,7 +58,7 @@ impl<'a> RuleMut<'a> for ParseObject {
     ) -> MinusOneResult<()> {
         let view = node.view();
         if view.kind() == "object" {
-            let mut map = HashMap::new();
+            let mut map = IndexMap::new();
             for child in view.iter() {
                 if child.kind() == "pair"
                     && let (Some(key), Some(value)) = (child.child(0), child.child(2))
@@ -233,7 +233,7 @@ impl ObjectField {
     }
 
     fn set_in_map(
-        map: &mut HashMap<String, JavaScript>,
+        map: &mut IndexMap<String, JavaScript>,
         keys: &[String],
         value: JavaScript,
     ) -> bool {
@@ -248,7 +248,7 @@ impl ObjectField {
 
         let head = keys[0].clone();
         let entry = map.entry(head).or_insert_with(|| Object {
-            map: HashMap::new(),
+            map: IndexMap::new(),
             to_string_override: None,
         });
         match entry {
@@ -267,7 +267,7 @@ impl ObjectField {
                 set_array_index(arr, keys, value)
             }
             Array(arr) => {
-                let mut map: HashMap<String, JavaScript> = arr
+                let mut map: IndexMap<String, JavaScript> = arr
                     .iter()
                     .enumerate()
                     .map(|(i, v)| (i.to_string(), v.clone()))

--- a/core/src/js/objects/objectify.rs
+++ b/core/src/js/objects/objectify.rs
@@ -2,8 +2,8 @@ use crate::js::JavaScript;
 use crate::js::JavaScript::*;
 use crate::js::Value::*;
 use crate::js::utils::{js_to_string_value, native_function};
+use indexmap::IndexMap;
 use log::trace;
-use std::collections::HashMap;
 
 fn function_name_from_source(source: &str) -> String {
     let trimmed = source.trim();
@@ -42,8 +42,8 @@ pub fn constructor_name(value: &JavaScript) -> &'static str {
     }
 }
 
-fn string_builtins(s: &str) -> HashMap<String, JavaScript> {
-    let mut map = HashMap::new();
+fn string_builtins(s: &str) -> IndexMap<String, JavaScript> {
+    let mut map = IndexMap::new();
 
     map.insert("length".to_string(), Raw(Num(s.chars().count() as f64)));
     map.insert(
@@ -89,8 +89,8 @@ fn string_builtins(s: &str) -> HashMap<String, JavaScript> {
     map
 }
 
-fn array_builtins(array: Vec<JavaScript>) -> HashMap<String, JavaScript> {
-    let mut map = HashMap::new();
+fn array_builtins(array: Vec<JavaScript>) -> IndexMap<String, JavaScript> {
+    let mut map = IndexMap::new();
     map.insert("length".to_string(), Raw(Num(array.len() as f64)));
 
     // jsfuck native code harvesters
@@ -118,7 +118,7 @@ pub fn as_object(value: &JavaScript) -> Option<JavaScript> {
 
     let mut to_string_override = None;
 
-    let mut map = HashMap::new();
+    let mut map = IndexMap::new();
     map.insert(
         "constructor".to_string(),
         native_function(constructor_name(value)),

--- a/core/src/js/var.rs
+++ b/core/src/js/var.rs
@@ -299,12 +299,14 @@ impl<'a> RuleMut<'a> for Var {
                         .flatten()
                         .and_then(|name| self.scope_manager.current().get_var(name).cloned())
                 });
-                let Some(Array(elems)) = iterable else {
-                    return Ok(());
-                };
-                let iter_values: Vec<JavaScript> = match op.as_str() {
-                    "in" => (0..elems.len()).map(|i| Raw(Str(i.to_string()))).collect(),
-                    "of" => elems,
+                let iter_values: Vec<JavaScript> = match (iterable, op.as_str()) {
+                    (Some(Array(elems)), "in") => {
+                        (0..elems.len()).map(|i| Raw(Str(i.to_string()))).collect()
+                    }
+                    (Some(Array(elems)), "of") => elems,
+                    (Some(Object { map, .. }), "in") => {
+                        map.keys().map(|k| Raw(Str(k.clone()))).collect()
+                    }
                     _ => return Ok(()),
                 };
                 let body_src = body.text()?.to_string();


### PR DESCRIPTION
I had to add `indexmap` because the order of the loop with a `for ... in ...` on objects is based on when has been inserted the fields 

Close #243 